### PR TITLE
fix: an issue where the @ command could not be used correctly in other workspaces and ensured cross-platform compatibility.

### DIFF
--- a/bin/claude-haha
+++ b/bin/claude-haha
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+#Get your current working directory and export it as an environment variable.
+export CALLER_DIR="$(pwd -W 2>/dev/null || pwd)"
+
 cd "$ROOT_DIR"
 
 # Force recovery CLI (simple readline REPL, no Ink TUI)

--- a/preload.ts
+++ b/preload.ts
@@ -15,3 +15,7 @@ Object.assign(globalThis, {
     ISSUES_EXPLAINER: '',
   },
 });
+// Switch to the current workspace
+if (process.env.CALLER_DIR) {
+  process.chdir(process.env.CALLER_DIR);
+}


### PR DESCRIPTION
# **Issue**
When invoking `bin/claude-haha` via a global script or alias, the hardcoded `cd "$ROOT_DIR"` inside the script causes `process.cwd()` to be permanently locked to the source code directory. This prevents the tool from operating within the user's actual project workspace.
# **Fix**
1. In `bin/claude-haha`, retrieved the actual calling directory by using `export CALLER_DIR="$(pwd -W 2>/dev/null || pwd)"`.

2. In `preload.ts`, read this environment variable and used `process.chdir()` during startup to switch the workspace back to the actual directory.
# **Testing**
Tested successfully on Windows (Git Bash). This approach gracefully falls back to standard commands, ensuring no impact on standard macOS / Linux environments.

# **Before**
<img width="1213" height="616" alt="image" src="https://github.com/user-attachments/assets/4be268db-e0a8-4423-9959-e353fe4b6479" />

# **After**
<img width="1550" height="613" alt="image" src="https://github.com/user-attachments/assets/dedf5065-11c1-49eb-88db-2db3a9a7e0c9" />