### PR TITLE
feat: add MiniMax-M2.7 as default model and update API endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,15 @@
 # ============================================================
 # MiniMax（直连 Anthropic 兼容接口）
+# 海外用户: ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+# 国内用户: ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
+# 可用模型: MiniMax-M2.7（默认）、MiniMax-M2.7-highspeed（更快）
 # ============================================================
-# ANTHROPIC_AUTH_TOKEN=your_token_here
-# ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
-# ANTHROPIC_MODEL=MiniMax-M2.7-highspeed
-# ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M2.7-highspeed
+# ANTHROPIC_AUTH_TOKEN=your_minimax_api_key_here
+# ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+# ANTHROPIC_MODEL=MiniMax-M2.7
+# ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M2.7
 # ANTHROPIC_DEFAULT_HAIKU_MODEL=MiniMax-M2.7-highspeed
-# ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M2.7-highspeed
+# ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M2.7
 # API_TIMEOUT_MS=3000000
 
 # ============================================================

--- a/docs/en/guide/third-party-models.md
+++ b/docs/en/guide/third-party-models.md
@@ -172,17 +172,27 @@ CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 
 ### MiniMax (pre-configured in .env.example)
 
+MiniMax provides an Anthropic-compatible API endpoint and can be connected directly without any proxy. Available models:
+
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.7` | Default recommended, excellent overall performance |
+| `MiniMax-M2.7-highspeed` | Faster responses, suitable for latency-sensitive use cases |
+
 ```env
-ANTHROPIC_AUTH_TOKEN=your_token_here
-ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
-ANTHROPIC_MODEL=MiniMax-M2.7-highspeed
-ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M2.7-highspeed
+ANTHROPIC_AUTH_TOKEN=your_minimax_api_key_here
+# International users: api.minimax.io; China users may use api.minimaxi.com
+ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+ANTHROPIC_MODEL=MiniMax-M2.7
+ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M2.7
 ANTHROPIC_DEFAULT_HAIKU_MODEL=MiniMax-M2.7-highspeed
-ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M2.7-highspeed
+ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M2.7
 API_TIMEOUT_MS=3000000
 DISABLE_TELEMETRY=1
 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 ```
+
+> **Get API Key**: Visit [MiniMax Open Platform](https://platform.minimax.io) to register and obtain an API key.
 
 ---
 

--- a/docs/guide/third-party-models.md
+++ b/docs/guide/third-party-models.md
@@ -172,17 +172,27 @@ CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 
 ### MiniMax（已在 .env.example 中配置）
 
+MiniMax 提供 Anthropic 兼容接口，支持直接接入，无需代理。可用模型：
+
+| 模型 | 说明 |
+|------|------|
+| `MiniMax-M2.7` | 默认推荐，综合性能优秀 |
+| `MiniMax-M2.7-highspeed` | 响应更快，适合对速度有要求的场景 |
+
 ```env
-ANTHROPIC_AUTH_TOKEN=your_token_here
-ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
-ANTHROPIC_MODEL=MiniMax-M2.7-highspeed
-ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M2.7-highspeed
+ANTHROPIC_AUTH_TOKEN=your_minimax_api_key_here
+# 海外用户使用 api.minimax.io，国内用户可改为 api.minimaxi.com
+ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+ANTHROPIC_MODEL=MiniMax-M2.7
+ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M2.7
 ANTHROPIC_DEFAULT_HAIKU_MODEL=MiniMax-M2.7-highspeed
-ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M2.7-highspeed
+ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M2.7
 API_TIMEOUT_MS=3000000
 DISABLE_TELEMETRY=1
 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 ```
+
+> **获取 API Key**：访问 [MiniMax 开放平台](https://platform.minimax.io) 注册并获取 API Key。
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `MiniMax-M2.7` as the recommended default chat model (previously only `MiniMax-M2.7-highspeed` was listed)
- Add `MiniMax-M2.7-highspeed` as a faster alternative for latency-sensitive use cases
- Update the base URL to `api.minimax.io/anthropic` (international endpoint) with a note that Chinese domestic users can use `api.minimaxi.com/anthropic`
- Add a model comparison table in both Chinese and English documentation
- Add API key registration link to [MiniMax Open Platform](https://platform.minimax.io)

## Changes

- `.env.example`: Updated MiniMax section with both models and international URL
- `docs/guide/third-party-models.md`: Updated MiniMax section with model table and improved description
- `docs/en/guide/third-party-models.md`: Same updates in English

## API Reference

- Chat (Anthropic Compatible): https://platform.minimax.io/docs/api-reference/text-anthropic-api

## Available MiniMax Models

| Model | Description |
|-------|-------------|
| `MiniMax-M2.7` | Default recommended, excellent overall performance |
| `MiniMax-M2.7-highspeed` | Faster responses, suitable for latency-sensitive use cases |