### PR TITLE
Fix bugs and memory leaks in adapter layer

### DIFF
--- a/adapters/common/__tests__/message-buffer.test.ts
+++ b/adapters/common/__tests__/message-buffer.test.ts
@@ -55,6 +55,37 @@ describe('MessageBuffer', () => {
     buf.reset()
   })
 
+  it('complete() waits for in-flight flush before sending final isComplete=true', async () => {
+    const flushed: Array<{ text: string; isComplete: boolean }> = []
+    let resolveFlush!: () => void
+    const buf = new MessageBuffer(
+      (text, isComplete) => {
+        flushed.push({ text, isComplete })
+        // First flush returns a promise that we control so we can force the
+        // "flushing = true" branch to be active when complete() is called.
+        if (flushed.length === 1) {
+          return new Promise<void>((r) => { resolveFlush = r })
+        }
+      },
+      50,    // short interval
+      1000,
+    )
+
+    buf.append('part1')
+    // Trigger a timer-based flush and wait until onFlush has been entered.
+    await new Promise((r) => setTimeout(r, 80))
+    // onFlush is now blocking (flushing = true). Append more text and complete.
+    buf.append('part2')
+    const completePromise = buf.complete()
+    // Unblock the first flush.
+    resolveFlush()
+    await completePromise
+
+    const allText = flushed.map((f) => f.text).join('')
+    expect(allText).toBe('part1part2')
+    expect(flushed[flushed.length - 1]!.isComplete).toBe(true)
+  })
+
   it('does not flush empty buffer on complete', async () => {
     const flushed: string[] = []
     const buf = new MessageBuffer(

--- a/adapters/common/message-buffer.ts
+++ b/adapters/common/message-buffer.ts
@@ -15,6 +15,7 @@ export class MessageBuffer {
   private timer: ReturnType<typeof setTimeout> | null = null
   private flushing = false
   private pendingComplete = false
+  private flushResolvers: Array<() => void> = []
 
   constructor(
     private onFlush: FlushCallback,
@@ -39,8 +40,9 @@ export class MessageBuffer {
       this.timer = null
     }
     if (this.flushing) {
-      // A flush is in-flight; mark pending so it fires after current flush finishes
-      this.pendingComplete = true
+      // A flush is in-flight; wait for it to finish, then do the final flush.
+      await new Promise<void>((resolve) => this.flushResolvers.push(resolve))
+      await this.flush(true)
       return
     }
     await this.flush(true)
@@ -81,7 +83,10 @@ export class MessageBuffer {
       console.error('[MessageBuffer] Flush error:', err)
     } finally {
       this.flushing = false
-      // If complete() was called while we were flushing, do the final flush now
+      // Notify any callers waiting in complete() for this flush to finish.
+      const resolvers = this.flushResolvers.splice(0)
+      for (const resolve of resolvers) resolve()
+      // Legacy pendingComplete path (belt-and-suspenders for any edge case).
       if (this.pendingComplete) {
         this.pendingComplete = false
         await this.flush(true)

--- a/adapters/common/message-dedup.ts
+++ b/adapters/common/message-dedup.ts
@@ -44,8 +44,6 @@ export class MessageDedup {
     for (const [key, ts] of this.store) {
       if (now - ts >= this.ttlMs) {
         this.store.delete(key)
-      } else {
-        break // Map preserves insertion order; once fresh, rest is fresh
       }
     }
   }

--- a/adapters/common/pairing.ts
+++ b/adapters/common/pairing.ts
@@ -19,6 +19,16 @@ const RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
 const RATE_LIMIT_MAX_ATTEMPTS = 5
 const failedAttempts = new Map<string, { count: number; firstAttempt: number }>()
 
+// Periodically evict expired rate-limit records to prevent unbounded growth.
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, rec] of failedAttempts) {
+    if (now - rec.firstAttempt > RATE_LIMIT_WINDOW_MS) {
+      failedAttempts.delete(key)
+    }
+  }
+}, 60_000).unref()
+
 function isRateLimited(userId: string | number): boolean {
   const key = String(userId)
   const record = failedAttempts.get(key)
@@ -53,6 +63,21 @@ function readConfigFile(): Record<string, any> {
   } catch {
     return {}
   }
+}
+
+// Cached read — refreshes every 5 seconds so hot paths (isAllowedUser) avoid
+// repeated synchronous disk I/O while still reacting quickly to config changes.
+const CONFIG_CACHE_TTL_MS = 5_000
+let configCache: { data: Record<string, any>; ts: number } | null = null
+
+function readConfigFileCached(): Record<string, any> {
+  const now = Date.now()
+  if (configCache && now - configCache.ts < CONFIG_CACHE_TTL_MS) {
+    return configCache.data
+  }
+  const data = readConfigFile()
+  configCache = { data, ts: now }
+  return data
 }
 
 function writeConfigFile(data: Record<string, any>): void {
@@ -134,6 +159,7 @@ export function tryPair(
   file[platform] = { ...platformConfig, pairedUsers }
   file.pairing = { code: null, expiresAt: null, createdAt: null } // 一次性使用
   writeConfigFile(file)
+  configCache = null // invalidate cache so isAllowedUser sees the new user immediately
 
   return true
 }
@@ -141,7 +167,7 @@ export function tryPair(
 /** 统一的用户授权检查（供各 adapter 调用） */
 export function isAllowedUser(platform: 'telegram' | 'feishu', userId: string | number): boolean {
   try {
-    const cfgFile = readConfigFile()
+    const cfgFile = readConfigFileCached()
     return isPaired(platform, userId, cfgFile)
   } catch {
     return false

--- a/adapters/feishu/index.ts
+++ b/adapters/feishu/index.ts
@@ -57,6 +57,12 @@ const media = new FeishuMediaService(larkClient, attachmentStore)
 attachmentStore.gc().catch((err) => {
   console.warn('[Feishu] AttachmentStore.gc failed:', err instanceof Error ? err.message : err)
 })
+// Run GC every 24 hours to prevent unbounded disk growth.
+setInterval(() => {
+  attachmentStore.gc().catch((err) => {
+    console.warn('[Feishu] AttachmentStore.gc failed:', err instanceof Error ? err.message : err)
+  })
+}, 24 * 60 * 60 * 1000).unref()
 
 // One streaming card lifecycle per chatId (CardKit main + patch fallback).
 const streamingCards = new Map<string, StreamingCard>()
@@ -117,6 +123,11 @@ function getUploadedKeys(chatId: string): Map<string, string> {
   if (!m) {
     m = new Map()
     uploadedImageKeys.set(chatId, m)
+  }
+  // Evict the oldest entry when the per-chat cache reaches its size limit.
+  if (m.size >= 500) {
+    const oldest = m.keys().next().value
+    if (oldest !== undefined) m.delete(oldest)
   }
   return m
 }

--- a/adapters/telegram/index.ts
+++ b/adapters/telegram/index.ts
@@ -49,6 +49,12 @@ const media = new TelegramMediaService(bot, attachmentStore)
 attachmentStore.gc().catch((err) => {
   console.warn('[Telegram] AttachmentStore.gc failed:', err instanceof Error ? err.message : err)
 })
+// Run GC every 24 hours to prevent unbounded disk growth.
+setInterval(() => {
+  attachmentStore.gc().catch((err) => {
+    console.warn('[Telegram] AttachmentStore.gc failed:', err instanceof Error ? err.message : err)
+  })
+}, 24 * 60 * 60 * 1000).unref()
 
 // Track placeholder messages for streaming updates
 const placeholders = new Map<string, { chatId: string; messageId: number }>()


### PR DESCRIPTION
此处借助AI修复了部分潜在bug
Six independent bugs — one causing silent message truncation, three causing unbounded memory/disk growth, one a hot-path I/O bottleneck, and one an incorrect sweep early-exit.

Changes
MessageBuffer.complete() — silent truncation fix (message-buffer.ts)
When complete() was called while a flush was in-flight, it set pendingComplete = true and returned immediately, so the caller's await buf.complete() resolved before the final isComplete=true flush ran. Now a flushResolvers queue suspends complete() until the in-flight flush's finally block fires, then issues the terminal flush:

if (this.flushing) {
  await new Promise<void>((resolve) => this.flushResolvers.push(resolve))
  await this.flush(true)
  return
}
failedAttempts Map — GC timer (pairing.ts)
Map was never pruned; a long-running process accumulates an entry per unique user who ever failed a pairing attempt. Added a 60 s setInterval(...).unref() sweep.

AttachmentStore.gc() — periodic execution (feishu/index.ts, telegram/index.ts)
gc() was called once at startup only. Downloaded attachments now re-GC'd every 24 h via setInterval(...).unref().

uploadedImageKeys inner Map — bounded to 500 entries (feishu/index.ts)
Per-chat image fingerprint cache was unbounded. getUploadedKeys() now evicts the oldest (insertion-order) entry when size >= 500.

isAllowedUser — config file read cache (pairing.ts)
Every inbound message triggered a synchronous fs.readFileSync. Added a 5 s TTL in-memory cache via readConfigFileCached(); cache is immediately invalidated after tryPair writes a new user.

MessageDedup.sweep() — remove incorrect early-break (message-dedup.ts)
Loop assumed Map insertion order guaranteed all entries after the first fresh one were also fresh — false once tryRecord refreshes a key mid-lifetime. Removed else { break }.

Copilot uses AI. Check for mistakes.