### PR TITLE
feat: 启用 AutoDream 功能

### DIFF
--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -34,7 +34,7 @@ import { CellWidth, CharPool, cellAt, createScreen, HyperlinkPool, isEmptyCellAt
 import { applySearchHighlight } from './searchHighlight.js';
 import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, type SelectionState, selectLineAt, selectWordAt, shiftAnchor, shiftSelection, shiftSelectionForFollow, startSelection, updateSelection } from './selection.js';
 import { SYNC_OUTPUT_SUPPORTED, supportsExtendedKeys, type Terminal, writeDiffToTerminal } from './terminal.js';
-import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ERASE_SCREEN } from './termio/csi.js';
+import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ERASE_SCROLLBACK, ERASE_SCREEN } from './termio/csi.js';
 import { DBP, DFE, DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec.js';
 import { CLEAR_ITERM2_PROGRESS, CLEAR_TAB_STATUS, setClipboard, supportsTabStatus, wrapForMultiplexer } from './termio/osc.js';
 import { TerminalWriteProvider } from './useTerminalNotification.js';
@@ -335,6 +335,11 @@ export default class Ink {
       this.needsEraseBeforePaint = true;
     }
 
+    // Main screen: clear terminal on resize to prevent ghosting
+    if (!this.altScreenActive && !this.isPaused && this.options.stdout.isTTY) {
+      this.options.stdout.write(ERASE_SCREEN + ERASE_SCROLLBACK + CURSOR_HOME);
+      this.log.reset();
+    }
     // Re-render the React tree with updated props so the context value changes.
     // React's commit phase will call onComputeLayout() to recalculate yoga layout
     // with the new dimensions, then call onRender() to render the updated frame.

--- a/src/memdir/paths.ts
+++ b/src/memdir/paths.ts
@@ -67,9 +67,7 @@ export function isAutoMemoryEnabled(): boolean {
  * directly in an `if` condition.
  */
 export function isExtractModeActive(): boolean {
-  if (!getFeatureValue_CACHED_MAY_BE_STALE('tengu_passport_quail', false)) {
-    return false
-  }
+  if (!isAutoMemoryEnabled()) return false
   return (
     !getIsNonInteractiveSession() ||
     getFeatureValue_CACHED_MAY_BE_STALE('tengu_slate_thimble', false)

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -303,11 +303,13 @@ export async function getAnthropicClient({
     authToken: isClaudeAISubscriber()
       ? getClaudeAIOAuthTokens()?.accessToken
       : undefined,
-    // Set baseURL from OAuth config when using staging OAuth
-    ...(process.env.USER_TYPE === 'ant' &&
-    isEnvTruthy(process.env.USE_STAGING_OAUTH)
-      ? { baseURL: getOauthConfig().BASE_API_URL }
-      : {}),
+    // Set baseURL from environment variable if provided
+    ...(process.env.ANTHROPIC_BASE_URL
+      ? { baseURL: process.env.ANTHROPIC_BASE_URL }
+      : process.env.USER_TYPE === 'ant' &&
+        isEnvTruthy(process.env.USE_STAGING_OAUTH)
+        ? { baseURL: getOauthConfig().BASE_API_URL }
+        : {}),
     ...ARGS,
     ...(isDebugToStdErr() && { logger: createStderrLogger() }),
   }

--- a/src/skills/bundled/dream.ts
+++ b/src/skills/bundled/dream.ts
@@ -1,34 +1,32 @@
-// @generated stub from scan-missing-imports
-// 该文件自动生成，对应 ant-internal 的 feature() gated 模块。
-// 所有外部 build 的代码路径在 DCE 后都不会真的执行这里的代码，这只是
-// bun build resolver 的占位符。
-const __target = function noop() {}
-const __handler: ProxyHandler<any> = {
-  get(_t, prop) {
-    if (prop === '__esModule') return true
-    if (prop === 'default') return new Proxy(__target, __handler)
-    if (prop === Symbol.toPrimitive) return () => undefined
-    if (prop === Symbol.iterator) return function* () {}
-    if (prop === Symbol.asyncIterator) return async function* () {}
-    if (prop === 'then') return undefined
-    return new Proxy(__target, __handler)
-  },
-  apply() {
-    return new Proxy(__target, __handler)
-  },
-  construct() {
-    return new Proxy(__target, __handler)
-  },
+import { isAutoMemoryEnabled, getAutoMemPath } from '../../memdir/paths.ts'
+import { isAutoDreamEnabled } from '../../services/autoDream/config.ts'
+import { recordConsolidation } from '../../services/autoDream/consolidationLock.ts'
+import { buildConsolidationPrompt } from '../../services/autoDream/consolidationPrompt.ts'
+import { getProjectDir } from '../../utils/sessionStorage.ts'
+import { getOriginalCwd } from '../../bootstrap/state.ts'
+import { registerBundledSkill } from '../bundledSkills.ts'
+
+export function registerDreamSkill(): void {
+  if (!isAutoMemoryEnabled()) return
+
+  registerBundledSkill({
+    name: 'dream',
+    description:
+      'Run memory consolidation (auto-dream) manually — review, deduplicate, and prune your auto-memory files',
+    whenToUse:
+      'when you want to clean up and organize accumulated memories, or after many sessions of use',
+    argumentHint: null,
+    isEnabled: () => isAutoDreamEnabled(),
+    context: 'inline',
+    async getPromptForCommand(_args: string) {
+      const memoryRoot = getAutoMemPath()
+      const transcriptDir = getProjectDir(getOriginalCwd())
+      await recordConsolidation()
+      const extra = ''
+
+      const prompt = buildConsolidationPrompt(memoryRoot, transcriptDir, extra)
+
+      return [{ type: 'text', text: prompt }]
+    },
+  })
 }
-const stub: any = new Proxy(__target, __handler)
-export default stub
-export const __stubMissing = true
-// 兼容常见的命名导出 —— 没列在这里的也会通过 default Proxy 兜底
-export const createCachedMCState = stub
-export const isCachedMicrocompactEnabled = stub
-export const isModelSupportedForCacheEditing = stub
-export const getCachedMCConfig = stub
-export const markToolsSentToAPI = stub
-export const resetCachedMCState = stub
-export const checkProtectedNamespace = stub
-export const getCoordinatorUserContext = stub

--- a/src/skills/bundled/index.ts
+++ b/src/skills/bundled/index.ts
@@ -22,10 +22,8 @@ export function initBundledSkills(): void {
   require('./simplify.js').registerSimplifySkill()
   require('./batch.js').registerBatchSkill()
   require('./stuck.js').registerStuckSkill()
-  if (feature('KAIROS') || feature('KAIROS_DREAM')) {
-    const { registerDreamSkill } = require('./dream.js')
-    registerDreamSkill()
-  }
+  const { registerDreamSkill } = require('./dream.js')
+  registerDreamSkill()
   if (feature('REVIEW_ARTIFACT')) {
     const { registerHunterSkill } = require('./hunter.js')
     registerHunterSkill()


### PR DESCRIPTION
- 移除 KAIROS 门控，启用 /dream 命令
- 将 dream.ts 从空壳实现为完整功能
- 移除 extractMemories 的远程 flag 依赖
- 使 AutoDream 在本地部署中可用

解锁了原本被官方内部 flag 封锁的记忆整合功能，提升本地部署的用户体验。