### PR TITLE
Add GPT-5.5 desktop model support

### DIFF
--- a/desktop/src/components/controls/ModelSelector.tsx
+++ b/desktop/src/components/controls/ModelSelector.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 export function ModelSelector({ value, onChange }: Props = {}) {
   const t = useTranslation()
-  const { currentModel: storeModel, availableModels, effortLevel, setModel, setEffort } = useSettingsStore()
+  const { currentModel: storeModel, availableModels, effortLevel, fetchAll, setModel, setEffort } = useSettingsStore()
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -59,7 +59,13 @@ export function ModelSelector({ value, onChange }: Props = {}) {
   return (
     <div ref={ref} className="relative">
       <button
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          const nextOpen = !open
+          setOpen(nextOpen)
+          if (nextOpen && !isControlled) {
+            void fetchAll().catch(() => {})
+          }
+        }}
         className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[var(--color-surface-container-low)] hover:bg-[var(--color-surface-hover)] rounded-full text-xs font-medium text-[var(--color-text-secondary)] transition-colors"
       >
         <span className="material-symbols-outlined text-[14px] text-[var(--color-brand)]">auto_awesome</span>
@@ -68,10 +74,10 @@ export function ModelSelector({ value, onChange }: Props = {}) {
       </button>
 
       {open && (
-        <div className="absolute right-0 bottom-full mb-2 w-[340px] rounded-xl bg-[var(--color-surface-container-lowest)] border border-[var(--color-border)] shadow-[var(--shadow-dropdown)] z-50">
+        <div className="absolute right-0 bottom-full mb-2 w-[340px] max-h-[min(520px,calc(100vh-140px))] overflow-hidden flex flex-col rounded-xl bg-[var(--color-surface-container-lowest)] border border-[var(--color-border)] shadow-[var(--shadow-dropdown)] z-50">
           {/* Models */}
-          <div className="p-3">
-            <div className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-outline)] mb-2 px-1">
+          <div className="p-3 flex-1 overflow-y-auto">
+            <div className="text-[10px] font-bold uppercase tracking-widest text-[var(--color-outline)] mb-2 px-1 sticky top-0 bg-[var(--color-surface-container-lowest)] z-10 py-1">
               {t('model.configuration')}
             </div>
             <div className="space-y-1">

--- a/docs/REMOTE_MODEL_CONFIG.md
+++ b/docs/REMOTE_MODEL_CONFIG.md
@@ -1,0 +1,120 @@
+# Remote Model Config
+
+The desktop app can now read remote model controls from the `data` object of:
+
+- `GET https://aiapi.space/api/status`
+
+This is meant for backend-side control of which models are visible in the desktop app, how they are ordered, and how internal alias models should route for sub-tasks and fast-path requests.
+
+## Supported fields
+
+### Preferred format
+
+Use one of these keys on `status.data`:
+
+- `desktop_models_config`
+- `desktop_model_config`
+- `desktop_models_json`
+- `desktop_models`
+
+The value may be either:
+
+- a JSON string
+- or a plain object
+
+Example:
+
+```json
+{
+  "desktop_models_config": {
+    "providerName": "丸美小沐",
+    "defaultModel": "gemini-3.1-pro-preview",
+    "models": [
+      {
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini Pro+",
+        "description": "主力写作模型",
+        "context": "1m",
+        "routing": {
+          "haiku": "gpt-5.4",
+          "sonnet": "gemini-3.1-pro-preview",
+          "opus": "gemini-3.1-pro-preview",
+          "smallFast": "gpt-5.4"
+        }
+      },
+      {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "description": "通用备用模型",
+        "context": "200k"
+      }
+    ]
+  }
+}
+```
+
+## Supported object keys
+
+- `providerName`: Optional. Overrides the provider label shown by `/api/models`.
+- `defaultModel` / `defaultModelId`: Optional. Used when the user has not explicitly selected a model, or when the previously selected model is no longer visible.
+- `models`: Optional array of models. Array order is preserved.
+- `visibleModels` / `visibleModelIds` / `modelIds`: Optional array of model IDs when you only want filtering without inline metadata.
+- `order` / `modelOrder`: Optional array of model IDs to reorder the final list.
+- `routing` / `modelRouting`: Optional map of model ID to internal routing.
+
+## Model entry shape
+
+Each item in `models` may be:
+
+- a string model ID, or
+- an object
+
+Supported object fields:
+
+- `id` / `modelId` / `model` / `model_name`
+- `name` / `displayName` / `display_name`
+- `description` / `desc` / `subtitle`
+- `context` / `contextWindow` / `context_window`
+- `enabled`, `visible`, `disabled`
+- `routing`
+- top-level routing keys:
+  - `main`
+  - `haiku`
+  - `sonnet`
+  - `opus`
+  - `smallFast`
+
+## Legacy compatible fields
+
+These are still supported on `status.data`:
+
+- `desktop_visible_models`
+  - CSV whitelist, for example: `"gpt-5.4,gemini-3.1-pro-preview,claude-sonnet-4-6"`
+- `desktop_model_order`
+  - CSV or JSON array
+- `desktop_default_model`
+- `desktop_model_routing`
+  - JSON string or object map
+
+## Routing behavior
+
+When the user selects a model:
+
+- `ANTHROPIC_MODEL` uses the selected model
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL`
+- `ANTHROPIC_DEFAULT_SONNET_MODEL`
+- `ANTHROPIC_DEFAULT_OPUS_MODEL`
+- `ANTHROPIC_SMALL_FAST_MODEL`
+
+will all follow the remote routing config for that model.
+
+If no routing is provided, all aliases fall back to the selected model itself.
+
+This ensures:
+
+- chat model selection
+- title generation
+- fast-path requests
+- internal sub-tasks / agents
+
+stay on a compatible route instead of falling back to old hardcoded defaults.

--- a/src/server/__tests__/conversation-service.test.ts
+++ b/src/server/__tests__/conversation-service.test.ts
@@ -73,6 +73,7 @@ describe('ConversationService', () => {
     expect(env.ANTHROPIC_AUTH_TOKEN).toBe('test-token')
     expect(env.ANTHROPIC_BASE_URL).toBe('https://example.invalid/anthropic')
     expect(env.ANTHROPIC_MODEL).toBe('test-model')
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
   })
 
   test('strips inherited provider env when desktop provider config exists', async () => {
@@ -194,6 +195,27 @@ describe('ConversationService', () => {
     expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gemini-3.1-pro-preview')
     expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gemini-3.1-pro-preview')
     expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gemini-3.1-pro-preview')
+  })
+
+  test('runtime invalidation changes the restart key even when model is unchanged', () => {
+    const service = new ConversationService() as any
+    const before = service.getRuntimeOptionsKey({
+      permissionMode: 'bypassPermissions',
+      model: 'gpt-5.4',
+      effort: 'high',
+      runtimeRevision: service.getRuntimeRevision(),
+    })
+
+    service.invalidateRuntimeOptions('test')
+
+    const after = service.getRuntimeOptionsKey({
+      permissionMode: 'bypassPermissions',
+      model: 'gpt-5.4',
+      effort: 'high',
+      runtimeRevision: service.getRuntimeRevision(),
+    })
+
+    expect(after).not.toBe(before)
   })
 
   test('uses bun entrypoint fallback on Windows dev mode', () => {

--- a/src/server/__tests__/conversation-service.test.ts
+++ b/src/server/__tests__/conversation-service.test.ts
@@ -12,6 +12,7 @@ describe('ConversationService', () => {
   let originalModel: string | undefined
   let originalEntrypoint: string | undefined
   let originalOAuthToken: string | undefined
+  let originalProviderManagedByHost: string | undefined
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-haha-conversation-service-'))
@@ -21,12 +22,14 @@ describe('ConversationService', () => {
     originalModel = process.env.ANTHROPIC_MODEL
     originalEntrypoint = process.env.CLAUDE_CODE_ENTRYPOINT
     originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN
+    originalProviderManagedByHost = process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
 
     process.env.CLAUDE_CONFIG_DIR = tmpDir
     process.env.ANTHROPIC_AUTH_TOKEN = 'test-token'
     process.env.ANTHROPIC_BASE_URL = 'https://example.invalid/anthropic'
     process.env.ANTHROPIC_MODEL = 'test-model'
     process.env.CLAUDE_CODE_OAUTH_TOKEN = 'inherited-parent-oauth-token'
+    delete process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
     // Clear inherited CLAUDE_CODE_ENTRYPOINT so tests can assert whether
     // buildChildEnv injects it or not without interference from the shell env.
     delete process.env.CLAUDE_CODE_ENTRYPOINT
@@ -51,6 +54,13 @@ describe('ConversationService', () => {
     if (originalOAuthToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN
     else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken
 
+    if (originalProviderManagedByHost === undefined) {
+      delete process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
+    } else {
+      process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST =
+        originalProviderManagedByHost
+    }
+
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
@@ -58,6 +68,8 @@ describe('ConversationService', () => {
     const service = new ConversationService() as any
     const env = (await service.buildChildEnv('D:\\workspace\\code\\myself_code\\cc-haha')) as Record<string, string>
 
+    expect(env.CLAUDE_CODE_ENTRYPOINT).toBe('claude-desktop')
+    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe('1')
     expect(env.ANTHROPIC_AUTH_TOKEN).toBe('test-token')
     expect(env.ANTHROPIC_BASE_URL).toBe('https://example.invalid/anthropic')
     expect(env.ANTHROPIC_MODEL).toBe('test-model')
@@ -75,6 +87,8 @@ describe('ConversationService', () => {
     const service = new ConversationService() as any
     const env = (await service.buildChildEnv('D:\\workspace\\code\\myself_code\\cc-haha')) as Record<string, string>
 
+    expect(env.CLAUDE_CODE_ENTRYPOINT).toBe('claude-desktop')
+    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe('1')
     expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
     expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
     expect(env.ANTHROPIC_MODEL).toBeUndefined()
@@ -127,7 +141,8 @@ describe('ConversationService', () => {
     const env = (await service.buildChildEnv('/tmp')) as Record<string, string>
 
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
-    expect(env.CLAUDE_CODE_ENTRYPOINT).toBeUndefined()
+    expect(env.CLAUDE_CODE_ENTRYPOINT).toBe('claude-desktop')
+    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe('1')
   })
 
   test('buildChildEnv does not leak inherited CLAUDE_CODE_OAUTH_TOKEN when official token is unavailable', async () => {
@@ -143,6 +158,7 @@ describe('ConversationService', () => {
     const env = (await service.buildChildEnv('/tmp')) as Record<string, string>
 
     expect(env.CLAUDE_CODE_ENTRYPOINT).toBe('claude-desktop')
+    expect(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBe('1')
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
   })
 
@@ -157,6 +173,27 @@ describe('ConversationService', () => {
       'com.claude-code-haha.desktop',
     )
     expect(env.CC_HAHA_DESKTOP_SERVER_URL).toBe('http://127.0.0.1:3456')
+  })
+
+  test('buildChildEnv falls back alias models to the selected main model when mappings are missing', async () => {
+    await fs.writeFile(
+      path.join(tmpDir, 'settings.json'),
+      JSON.stringify({
+        env: {
+          ANTHROPIC_MODEL: 'gemini-3.1-pro-preview',
+        },
+      }),
+      'utf-8',
+    )
+
+    const service = new ConversationService() as any
+    const env = (await service.buildChildEnv('/tmp')) as Record<string, string>
+
+    expect(env.ANTHROPIC_MODEL).toBe('gemini-3.1-pro-preview')
+    expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBe('gemini-3.1-pro-preview')
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gemini-3.1-pro-preview')
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gemini-3.1-pro-preview')
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gemini-3.1-pro-preview')
   })
 
   test('uses bun entrypoint fallback on Windows dev mode', () => {

--- a/src/server/__tests__/xiaomu-models.test.ts
+++ b/src/server/__tests__/xiaomu-models.test.ts
@@ -28,7 +28,7 @@ function makeRequest(
   return { req, url, segments }
 }
 
-function installAiapiMock(): void {
+function installAiapiMock(statusOverrides: Record<string, unknown> = {}): void {
   const statusPayload = {
     success: true,
     data: {
@@ -56,6 +56,7 @@ function installAiapiMock(): void {
           },
         ],
       }),
+      ...statusOverrides,
     },
   }
 
@@ -65,6 +66,13 @@ function installAiapiMock(): void {
       {
         model_name: 'gpt-5.4',
         display_name: '灵感引擎Pro',
+        quota_type: 0,
+        model_ratio: 0.8,
+        completion_ratio: 8,
+      },
+      {
+        model_name: 'gpt-5.5',
+        display_name: 'GPT-5.5',
         quota_type: 0,
         model_ratio: 0.8,
         completion_ratio: 8,
@@ -141,6 +149,21 @@ describe('xiaomu remote model management', () => {
       'gemini-3.1-pro-preview',
       'gpt-5.4',
     ])
+  })
+
+  test('GET /api/models keeps gpt-5.5 visible when remote whitelist omits it', async () => {
+    resetXiaomuModelCatalogCache()
+    installAiapiMock({
+      desktop_models_config: '',
+      desktop_visible_models: 'gpt-5.4,gemini-3.1-pro-preview',
+    })
+
+    const { req, url, segments } = makeRequest('GET', '/api/models')
+    const res = await handleModelsApi(req, url, segments)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.models.map((model: { id: string }) => model.id)).toContain('gpt-5.5')
   })
 
   test('GET /api/models/current falls back to remote default and syncs routing env', async () => {

--- a/src/server/__tests__/xiaomu-models.test.ts
+++ b/src/server/__tests__/xiaomu-models.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import * as fs from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+import { handleModelsApi } from '../api/models.js'
+import { ProviderService } from '../services/providerService.js'
+import { resetXiaomuModelCatalogCache } from '../services/xiaomuModelService.js'
+
+let tmpDir: string
+let originalConfigDir: string | undefined
+let originalFetch: typeof globalThis.fetch
+
+function makeRequest(
+  method: string,
+  urlStr: string,
+  body?: Record<string, unknown>,
+): { req: Request; url: URL; segments: string[] } {
+  const url = new URL(urlStr, 'http://localhost:3456')
+  const init: RequestInit = { method }
+
+  if (body) {
+    init.headers = { 'Content-Type': 'application/json' }
+    init.body = JSON.stringify(body)
+  }
+
+  const req = new Request(url.toString(), init)
+  const segments = url.pathname.split('/').filter(Boolean)
+  return { req, url, segments }
+}
+
+function installAiapiMock(): void {
+  const statusPayload = {
+    success: true,
+    data: {
+      system_name: '远程模型中心',
+      desktop_models_config: JSON.stringify({
+        defaultModel: 'gemini-3.1-pro-preview',
+        models: [
+          {
+            id: 'gemini-3.1-pro-preview',
+            name: 'Gemini Pro+',
+            description: '远程主模型',
+            context: '1m',
+            routing: {
+              haiku: 'gpt-5.4',
+              sonnet: 'gemini-3.1-pro-preview',
+              opus: 'gemini-3.1-pro-preview',
+              smallFast: 'gpt-5.4',
+            },
+          },
+          {
+            id: 'gpt-5.4',
+            name: 'GPT-5.4',
+            description: '远程备用模型',
+            context: '200k',
+          },
+        ],
+      }),
+    },
+  }
+
+  const pricingPayload = {
+    success: true,
+    data: [
+      {
+        model_name: 'gpt-5.4',
+        display_name: '灵感引擎Pro',
+        quota_type: 0,
+        model_ratio: 0.8,
+        completion_ratio: 8,
+      },
+      {
+        model_name: 'gemini-3.1-pro-preview',
+        display_name: '智写Pro+',
+        quota_type: 0,
+        model_ratio: 1.8,
+        completion_ratio: 5.5,
+      },
+      {
+        model_name: 'claude-sonnet-4-6',
+        display_name: '创作大师',
+        quota_type: 0,
+        model_ratio: 4.14,
+        completion_ratio: 5,
+      },
+    ],
+  }
+
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url
+
+    if (url.includes('/api/status')) {
+      return Response.json(statusPayload)
+    }
+    if (url.includes('/api/pricing')) {
+      return Response.json(pricingPayload)
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`)
+  }) as typeof globalThis.fetch
+}
+
+async function readJson(filePath: string): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(filePath, 'utf-8')
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+describe('xiaomu remote model management', () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xiaomu-models-test-'))
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = tmpDir
+    originalFetch = globalThis.fetch
+    resetXiaomuModelCatalogCache()
+    installAiapiMock()
+  })
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    resetXiaomuModelCatalogCache()
+
+    if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR
+    else process.env.CLAUDE_CONFIG_DIR = originalConfigDir
+
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('GET /api/models honors remote ordering and provider metadata', async () => {
+    const { req, url, segments } = makeRequest('GET', '/api/models')
+    const res = await handleModelsApi(req, url, segments)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.provider.name).toBe('远程模型中心')
+    expect(body.meta.remoteManaged).toBe(true)
+    expect(body.models.map((model: { id: string }) => model.id)).toEqual([
+      'gemini-3.1-pro-preview',
+      'gpt-5.4',
+    ])
+  })
+
+  test('GET /api/models/current falls back to remote default and syncs routing env', async () => {
+    await fs.writeFile(
+      path.join(tmpDir, 'settings.json'),
+      JSON.stringify({ model: 'claude-sonnet-4-6' }),
+      'utf-8',
+    )
+
+    const { req, url, segments } = makeRequest('GET', '/api/models/current')
+    const res = await handleModelsApi(req, url, segments)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.model.id).toBe('gemini-3.1-pro-preview')
+
+    const topSettings = await readJson(path.join(tmpDir, 'settings.json'))
+    const ccHahaSettings = await readJson(path.join(tmpDir, 'cc-haha', 'settings.json'))
+    const topEnv = topSettings.env as Record<string, string>
+    const ccEnv = ccHahaSettings.env as Record<string, string>
+
+    expect(topSettings.model).toBeUndefined()
+    expect(topEnv.ANTHROPIC_MODEL).toBe('gemini-3.1-pro-preview')
+    expect(topEnv.ANTHROPIC_SMALL_FAST_MODEL).toBe('gpt-5.4')
+    expect(topEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4')
+    expect(ccEnv.ANTHROPIC_MODEL).toBe('gemini-3.1-pro-preview')
+    expect(ccEnv.ANTHROPIC_SMALL_FAST_MODEL).toBe('gpt-5.4')
+  })
+
+  test('PUT /api/models/current persists the selected model and routing env', async () => {
+    const { req, url, segments } = makeRequest('PUT', '/api/models/current', {
+      modelId: 'gpt-5.4',
+    })
+    const res = await handleModelsApi(req, url, segments)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.model).toBe('gpt-5.4')
+
+    const topSettings = await readJson(path.join(tmpDir, 'settings.json'))
+    const ccHahaSettings = await readJson(path.join(tmpDir, 'cc-haha', 'settings.json'))
+    const topEnv = topSettings.env as Record<string, string>
+    const ccEnv = ccHahaSettings.env as Record<string, string>
+
+    expect(topSettings.model).toBe('gpt-5.4')
+    expect(topEnv.ANTHROPIC_MODEL).toBe('gpt-5.4')
+    expect(topEnv.ANTHROPIC_SMALL_FAST_MODEL).toBe('gpt-5.4')
+    expect(ccEnv.ANTHROPIC_MODEL).toBe('gpt-5.4')
+    expect(ccEnv.ANTHROPIC_SMALL_FAST_MODEL).toBe('gpt-5.4')
+  })
+})
+
+describe('provider model routing sync', () => {
+  let providerTmpDir: string
+  let providerOriginalConfigDir: string | undefined
+
+  beforeEach(async () => {
+    providerTmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'provider-routing-test-'))
+    providerOriginalConfigDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = providerTmpDir
+  })
+
+  afterEach(async () => {
+    if (providerOriginalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR
+    else process.env.CLAUDE_CONFIG_DIR = providerOriginalConfigDir
+
+    await fs.rm(providerTmpDir, { recursive: true, force: true })
+  })
+
+  test('active providers persist small-fast routing alongside the selected models', async () => {
+    const service = new ProviderService()
+    const provider = await service.addProvider({
+      presetId: 'custom',
+      name: '自定义供应商',
+      apiKey: 'sk-provider-test',
+      baseUrl: 'https://api.example.com',
+      apiFormat: 'anthropic',
+      models: {
+        main: 'gpt-5.4',
+        haiku: 'gpt-5.4-mini',
+        sonnet: 'gpt-5.4',
+        opus: 'gpt-5.5',
+      },
+    })
+
+    await service.activateProvider(provider.id)
+
+    const settings = await readJson(path.join(providerTmpDir, 'cc-haha', 'settings.json'))
+    const env = settings.env as Record<string, string>
+
+    expect(env.ANTHROPIC_MODEL).toBe('gpt-5.4')
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini')
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4')
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.5')
+    expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBe('gpt-5.4-mini')
+  })
+})

--- a/src/server/api/models.ts
+++ b/src/server/api/models.ts
@@ -10,6 +10,7 @@
 
 import { SettingsService } from '../services/settingsService.js'
 import { ProviderService } from '../services/providerService.js'
+import { conversationService } from '../services/conversationService.js'
 import {
   modelEnvMatches,
   normalizeModelRouting,
@@ -102,6 +103,7 @@ async function reconcileXiaomuCurrentModel(
     catalog.routingById[currentModelId] || normalizeModelRouting(undefined, currentModelId)
   if (!modelEnvMatches(env, desiredRouting)) {
     await syncSelectedModelRouting(currentModelId, { catalog })
+    conversationService.invalidateRuntimeOptions('xiaomu model routing reconciled')
   }
 
   return {
@@ -196,6 +198,7 @@ async function handleCurrentModel(req: Request): Promise<Response> {
       })
       if (!modelEnvMatches(env, desiredRouting)) {
         await syncSelectedModelRouting(currentModelId, { activeProvider })
+        conversationService.invalidateRuntimeOptions('provider model routing reconciled')
       }
     } else {
       const reconciled = await reconcileXiaomuCurrentModel(explicitModel, env)
@@ -250,6 +253,7 @@ async function handleCurrentModel(req: Request): Promise<Response> {
       modelContext: contextTier || undefined,
     })
     await syncSelectedModelRouting(baseId, { activeProvider, catalog })
+    conversationService.invalidateRuntimeOptions('model changed')
 
     return Response.json({ ok: true, model: normalizedModelId })
   }
@@ -276,6 +280,7 @@ async function handleEffort(req: Request): Promise<Response> {
       )
     }
     await settingsService.updateUserSettings({ effort: level })
+    conversationService.invalidateRuntimeOptions('effort changed')
     return Response.json({ ok: true, level })
   }
 

--- a/src/server/api/models.ts
+++ b/src/server/api/models.ts
@@ -1,68 +1,131 @@
 /**
  * Models REST API
  *
- * GET  /api/models          — 获取可用模型列表
- * GET  /api/models/current  — 获取当前选中的模型
- * PUT  /api/models/current  — 切换模型
- * GET  /api/effort          — 获取 Effort 等级
- * PUT  /api/effort          — 设置 Effort 等级
+ * GET  /api/models          - Get available models
+ * GET  /api/models/current  - Get the currently selected model
+ * PUT  /api/models/current  - Switch the current model
+ * GET  /api/effort          - Get current effort level
+ * PUT  /api/effort          - Update effort level
  */
 
 import { SettingsService } from '../services/settingsService.js'
 import { ProviderService } from '../services/providerService.js'
+import {
+  modelEnvMatches,
+  normalizeModelRouting,
+  routingFromProviderModels,
+  toModelEnv,
+} from '../services/modelRoutingService.js'
+import { patchSettingsEnv } from '../services/settingsSyncService.js'
+import {
+  DEFAULT_XIAOMU_MODEL_ID,
+  getXiaomuModelCatalog,
+  type XiaomuModel,
+} from '../services/xiaomuModelService.js'
 import { ApiError, errorResponse } from '../middleware/errorHandler.js'
 
-// ─── Fallback models (used when no provider is configured) ────────────────────
-
-const DEFAULT_MODELS = [
-  {
-    id: 'claude-opus-4-7',
-    name: 'Opus 4.7',
-    description: 'Most capable for ambitious work',
-    context: '1m',
-  },
-  {
-    id: 'claude-sonnet-4-6',
-    name: 'Sonnet 4.6',
-    description: 'Most efficient for everyday tasks',
-    context: '200k',
-  },
-  {
-    id: 'claude-haiku-4-5',
-    name: 'Haiku 4.5',
-    description: 'Fastest for quick answers',
-    context: '200k',
-  },
-] as const
-
 const EFFORT_LEVELS = ['low', 'medium', 'high', 'max'] as const
-
-const DEFAULT_MODEL = 'claude-opus-4-7'
 const DEFAULT_EFFORT = 'max'
+const XIAOMU_CONFIG_FALLBACK_DIR = '.xiaomu-ai'
 
 const settingsService = new SettingsService()
 const providerService = new ProviderService()
 
-// ─── Router ───────────────────────────────────────────────────────────────────
+type ModelInfo = XiaomuModel
+
+function buildProviderModelList(activeProvider: {
+  models: { main: string; haiku: string; sonnet: string; opus: string }
+}): ModelInfo[] {
+  const candidates = [
+    { id: activeProvider.models.main, name: activeProvider.models.main, description: 'Main model', context: '' },
+    { id: activeProvider.models.haiku, name: activeProvider.models.haiku, description: 'Haiku model', context: '' },
+    { id: activeProvider.models.sonnet, name: activeProvider.models.sonnet, description: 'Sonnet model', context: '' },
+    { id: activeProvider.models.opus, name: activeProvider.models.opus, description: 'Opus model', context: '' },
+  ]
+
+  const seen = new Set<string>()
+  return candidates.filter((model) => {
+    if (!model.id || seen.has(model.id)) return false
+    seen.add(model.id)
+    return true
+  })
+}
+
+async function syncSelectedModelRouting(
+  modelId: string,
+  options: {
+    activeProvider?: {
+      models: { main: string; haiku: string; sonnet: string; opus: string }
+    } | null
+    catalog?: Awaited<ReturnType<typeof getXiaomuModelCatalog>> | null
+  },
+): Promise<void> {
+  const routing = options.activeProvider
+    ? routingFromProviderModels({
+        ...options.activeProvider.models,
+        main: modelId,
+      })
+    : options.catalog?.routingById[modelId] || normalizeModelRouting(undefined, modelId)
+
+  await patchSettingsEnv(toModelEnv(routing), {
+    fallbackDirName: XIAOMU_CONFIG_FALLBACK_DIR,
+    topLevel: !options.activeProvider,
+    ccHaha: true,
+  })
+}
+
+async function reconcileXiaomuCurrentModel(
+  explicitModel: string,
+  env: Record<string, string>,
+): Promise<{
+  availableModels: ModelInfo[]
+  currentModelId: string
+  currentModelName: string
+  contextTier?: string
+}> {
+  const catalog = await getXiaomuModelCatalog()
+  const availableModels = catalog.models
+  const availableIds = new Set(availableModels.map((model) => model.id))
+
+  let currentModelId = explicitModel || catalog.defaultModelId || DEFAULT_XIAOMU_MODEL_ID
+  const explicitModelIsInvalid = !!explicitModel && !availableIds.has(explicitModel)
+
+  if (!availableIds.has(currentModelId)) {
+    currentModelId = catalog.defaultModelId || availableModels[0]?.id || DEFAULT_XIAOMU_MODEL_ID
+  }
+
+  if (explicitModelIsInvalid) {
+    await settingsService.updateUserSettings({ model: undefined, modelContext: undefined })
+  }
+
+  const desiredRouting =
+    catalog.routingById[currentModelId] || normalizeModelRouting(undefined, currentModelId)
+  if (!modelEnvMatches(env, desiredRouting)) {
+    await syncSelectedModelRouting(currentModelId, { catalog })
+  }
+
+  return {
+    availableModels,
+    currentModelId,
+    currentModelName: currentModelId,
+  }
+}
 
 export async function handleModelsApi(
   req: Request,
-  url: URL,
+  _url: URL,
   segments: string[],
 ): Promise<Response> {
   try {
-    const resource = segments[1] // 'models' | 'effort'
-    const sub = segments[2] // 'current' | undefined
+    const resource = segments[1]
+    const sub = segments[2]
 
-    // ── /api/effort ───────────────────────────────────────────────────
     if (resource === 'effort') {
       return await handleEffort(req)
     }
 
-    // ── /api/models/* ─────────────────────────────────────────────────
     switch (sub) {
       case undefined:
-        // GET /api/models — 优先从激活的 Provider 读取模型列表
         if (req.method !== 'GET') throw methodNotAllowed(req.method)
         return await handleModelsList()
 
@@ -77,25 +140,26 @@ export async function handleModelsApi(
   }
 }
 
-// ─── Handlers ─────────────────────────────────────────────────────────────────
-
 async function handleModelsList(): Promise<Response> {
   const { providers, activeId } = await providerService.listProviders()
-  const activeProvider = activeId ? providers.find((p) => p.id === activeId) : null
+  const activeProvider = activeId ? providers.find((provider) => provider.id === activeId) : null
+
   if (activeProvider) {
-    // Convert ModelMapping to model list for API compatibility
-    const modelList = [
-      { id: activeProvider.models.main, name: activeProvider.models.main, description: 'Main model', context: '' },
-      ...(activeProvider.models.haiku !== activeProvider.models.main ? [{ id: activeProvider.models.haiku, name: activeProvider.models.haiku, description: 'Haiku model', context: '' }] : []),
-      ...(activeProvider.models.sonnet !== activeProvider.models.main ? [{ id: activeProvider.models.sonnet, name: activeProvider.models.sonnet, description: 'Sonnet model', context: '' }] : []),
-      ...(activeProvider.models.opus !== activeProvider.models.main ? [{ id: activeProvider.models.opus, name: activeProvider.models.opus, description: 'Opus model', context: '' }] : []),
-    ]
     return Response.json({
-      models: modelList,
+      models: buildProviderModelList(activeProvider),
       provider: { id: activeProvider.id, name: activeProvider.name },
     })
   }
-  return Response.json({ models: DEFAULT_MODELS, provider: null })
+
+  const catalog = await getXiaomuModelCatalog()
+  return Response.json({
+    models: catalog.models,
+    provider: { id: 'xiaomu', name: catalog.providerName },
+    meta: {
+      remoteManaged: catalog.remoteManaged,
+      defaultModelId: catalog.defaultModelId,
+    },
+  })
 }
 
 async function handleCurrentModel(req: Request): Promise<Response> {
@@ -103,48 +167,46 @@ async function handleCurrentModel(req: Request): Promise<Response> {
     const settings = await settingsService.getUserSettings()
     const explicitModel = (settings.model as string) || ''
     const contextTier = (settings.modelContext as string) || undefined
-    const env = (settings.env as Record<string, string>) || {}
+    const env = ((settings.env as Record<string, string>) || {})
 
-    // Build the full model list: prefer active provider's models, fall back to defaults
     const { providers, activeId } = await providerService.listProviders()
-    const activeProvider = activeId ? providers.find((p) => p.id === activeId) : null
+    const activeProvider = activeId ? providers.find((provider) => provider.id === activeId) : null
 
+    let availableModels: ModelInfo[]
     let currentModelId: string
     let currentModelName: string
 
     if (activeProvider) {
-      // Provider is active — use the model from env (set by syncToSettings when provider was activated)
-      // unless user explicitly set a different model ID in settings
+      availableModels = buildProviderModelList(activeProvider)
+      const availableIds = new Set(availableModels.map((model) => model.id))
       const providerEnvModel = env.ANTHROPIC_MODEL
-      if (providerEnvModel && (!explicitModel || explicitModel === DEFAULT_MODEL)) {
-        // No explicit model override — use the provider's configured model
-        currentModelId = providerEnvModel
-        currentModelName = providerEnvModel
-      } else {
-        // User explicitly set a model (possibly from the provider's model list)
-        currentModelId = explicitModel || providerEnvModel || activeProvider.models.main
-        currentModelName = currentModelId
+      currentModelId = explicitModel || providerEnvModel || activeProvider.models.main
+
+      if (!availableIds.has(currentModelId)) {
+        currentModelId = availableIds.has(providerEnvModel || '')
+          ? (providerEnvModel as string)
+          : activeProvider.models.main
+      }
+
+      currentModelName = currentModelId
+
+      const desiredRouting = routingFromProviderModels({
+        ...activeProvider.models,
+        main: currentModelId,
+      })
+      if (!modelEnvMatches(env, desiredRouting)) {
+        await syncSelectedModelRouting(currentModelId, { activeProvider })
       }
     } else {
-      // No provider — use settings model with context tier
-      currentModelId = explicitModel || DEFAULT_MODEL
-      currentModelName = currentModelId
+      const reconciled = await reconcileXiaomuCurrentModel(explicitModel, env)
+      availableModels = reconciled.availableModels
+      currentModelId = reconciled.currentModelId
+      currentModelName = reconciled.currentModelName
     }
 
     const lookupId = contextTier ? `${currentModelId}:${contextTier}` : currentModelId
-
-    // Build available models for name lookup
-    const availableModels = activeProvider
-      ? [
-          { id: activeProvider.models.main, name: activeProvider.models.main, description: 'Main model', context: '' },
-          ...(activeProvider.models.haiku && activeProvider.models.haiku !== activeProvider.models.main ? [{ id: activeProvider.models.haiku, name: activeProvider.models.haiku, description: 'Haiku model', context: '' }] : []),
-          ...(activeProvider.models.sonnet && activeProvider.models.sonnet !== activeProvider.models.main ? [{ id: activeProvider.models.sonnet, name: activeProvider.models.sonnet, description: 'Sonnet model', context: '' }] : []),
-          ...(activeProvider.models.opus && activeProvider.models.opus !== activeProvider.models.main ? [{ id: activeProvider.models.opus, name: activeProvider.models.opus, description: 'Opus model', context: '' }] : []),
-        ]
-      : DEFAULT_MODELS
-
-    const modelEntry = availableModels.find((m) => m.id === lookupId)
-      || availableModels.find((m) => m.id === currentModelId)
+    const modelEntry = availableModels.find((model) => model.id === lookupId)
+      || availableModels.find((model) => model.id === currentModelId)
       || {
         id: currentModelId,
         name: currentModelName,
@@ -152,31 +214,44 @@ async function handleCurrentModel(req: Request): Promise<Response> {
         context: contextTier || 'unknown',
       }
 
-    return Response.json({ model: { ...modelEntry, context: contextTier || modelEntry.context } })
+    return Response.json({
+      model: {
+        ...modelEntry,
+        context: contextTier || modelEntry.context,
+      },
+    })
   }
 
   if (req.method === 'PUT') {
     const body = await parseJsonBody(req)
     const modelId = body.modelId
-    if (typeof modelId !== 'string' || !modelId) {
+    if (typeof modelId !== 'string' || !modelId.trim()) {
       throw ApiError.badRequest('Missing or invalid "modelId" in request body')
     }
 
-    // Parse composite IDs like 'claude-opus-4-7-20250610:1m'
-    // Persist the base model ID for CLI compatibility and context tier separately
-    const colonIdx = modelId.indexOf(':')
-    const baseId = colonIdx !== -1 ? modelId.slice(0, colonIdx) : modelId
-    const contextTier = colonIdx !== -1 ? modelId.slice(colonIdx + 1) : undefined
+    const normalizedModelId = modelId.trim()
+    const colonIndex = normalizedModelId.indexOf(':')
+    const baseId = colonIndex !== -1 ? normalizedModelId.slice(0, colonIndex) : normalizedModelId
+    const contextTier = colonIndex !== -1 ? normalizedModelId.slice(colonIndex + 1) : undefined
 
-    const updates: Record<string, unknown> = { model: baseId }
-    if (contextTier) {
-      updates.modelContext = contextTier
-    } else {
-      // Clear context tier when switching to a non-composite model
-      updates.modelContext = undefined
+    const { providers, activeId } = await providerService.listProviders()
+    const activeProvider = activeId ? providers.find((provider) => provider.id === activeId) : null
+    const catalog = activeProvider ? null : await getXiaomuModelCatalog()
+    const availableModels = activeProvider
+      ? buildProviderModelList(activeProvider)
+      : catalog!.models
+
+    if (!availableModels.some((model) => model.id === baseId)) {
+      throw ApiError.badRequest(`Model "${baseId}" is not available right now`)
     }
-    await settingsService.updateUserSettings(updates)
-    return Response.json({ ok: true, model: modelId })
+
+    await settingsService.updateUserSettings({
+      model: baseId,
+      modelContext: contextTier || undefined,
+    })
+    await syncSelectedModelRouting(baseId, { activeProvider, catalog })
+
+    return Response.json({ ok: true, model: normalizedModelId })
   }
 
   throw methodNotAllowed(req.method)
@@ -206,8 +281,6 @@ async function handleEffort(req: Request): Promise<Response> {
 
   throw methodNotAllowed(req.method)
 }
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 async function parseJsonBody(req: Request): Promise<Record<string, unknown>> {
   try {

--- a/src/server/services/conversationService.ts
+++ b/src/server/services/conversationService.ts
@@ -44,6 +44,7 @@ type SessionStartOptions = {
   permissionMode?: string
   model?: string
   effort?: string
+  runtimeRevision?: number
 }
 
 export class ConversationStartupError extends Error {
@@ -64,6 +65,7 @@ export class ConversationStartupError extends Error {
 
 export class ConversationService {
   private sessions = new Map<string, SessionProcess>()
+  private runtimeRevision = 0
 
   async startSession(
     sessionId: string,
@@ -307,6 +309,19 @@ export class ConversationService {
     return !!session && session.runtimeOptionsKey !== this.getRuntimeOptionsKey(options)
   }
 
+  invalidateRuntimeOptions(reason?: string): void {
+    this.runtimeRevision += 1
+    console.log(
+      `[ConversationService] Runtime options invalidated (${this.runtimeRevision})${
+        reason ? `: ${reason}` : ''
+      }`,
+    )
+  }
+
+  getRuntimeRevision(): number {
+    return this.runtimeRevision
+  }
+
   authorizeSdkConnection(
     sessionId: string,
     token: string | null | undefined,
@@ -486,6 +501,7 @@ export class ConversationService {
       permissionMode: options?.permissionMode || 'default',
       model: options?.model || '',
       effort: options?.effort || '',
+      runtimeRevision: options?.runtimeRevision || 0,
     })
   }
 
@@ -689,7 +705,15 @@ export class ConversationService {
       )
       return !hasProviderEnv
     } catch {
-      return true
+      return ![
+        'ANTHROPIC_API_KEY',
+        'ANTHROPIC_AUTH_TOKEN',
+        'ANTHROPIC_BASE_URL',
+      ].some(
+        (key) =>
+          typeof process.env[key] === 'string' &&
+          process.env[key]!.trim().length > 0,
+      )
     }
   }
 

--- a/src/server/services/conversationService.ts
+++ b/src/server/services/conversationService.ts
@@ -37,6 +37,7 @@ type SessionProcess = {
       permissionSuggestions?: unknown[]
     }
   >
+  runtimeOptionsKey: string
 }
 
 type SessionStartOptions = {
@@ -150,6 +151,7 @@ export class ConversationService {
       stderrLines: [],
       sdkMessages: [],
       pendingPermissionRequests: new Map(),
+      runtimeOptionsKey: this.getRuntimeOptionsKey(options),
     }
     this.sessions.set(sessionId, session)
 
@@ -295,6 +297,14 @@ export class ConversationService {
   getSessionPermissionMode(sessionId: string): string {
     const session = this.sessions.get(sessionId)
     return session?.permissionMode || 'default'
+  }
+
+  needsRestartForRuntimeOptions(
+    sessionId: string,
+    options?: SessionStartOptions,
+  ): boolean {
+    const session = this.sessions.get(sessionId)
+    return !!session && session.runtimeOptionsKey !== this.getRuntimeOptionsKey(options)
   }
 
   authorizeSdkConnection(
@@ -471,6 +481,14 @@ export class ConversationService {
     return args
   }
 
+  private getRuntimeOptionsKey(options: SessionStartOptions | undefined): string {
+    return JSON.stringify({
+      permissionMode: options?.permissionMode || 'default',
+      model: options?.model || '',
+      effort: options?.effort || '',
+    })
+  }
+
   private async buildChildEnv(
     workDir: string,
     sdkUrl?: string,
@@ -490,6 +508,7 @@ export class ConversationService {
       'ANTHROPIC_DEFAULT_HAIKU_MODEL',
       'ANTHROPIC_DEFAULT_SONNET_MODEL',
       'ANTHROPIC_DEFAULT_OPUS_MODEL',
+      'ANTHROPIC_SMALL_FAST_MODEL',
     ] as const
 
     const cleanEnv = { ...process.env }
@@ -510,8 +529,63 @@ export class ConversationService {
       }
     }
 
+    // xiaomu: 强制读 settings.json 的 env，直接注入到子进程
+    // 因为 shouldStripInheritedProviderEnv 会把 process.env 里的 ANTHROPIC_* 剥掉，
+    // 而 CLI 内部的"小模型"( session title / 子任务 ) 如果没拿到 ANTHROPIC_SMALL_FAST_MODEL
+    // 会 fallback 到硬编码的 claude-haiku-4-5-20251001 → 打到 aiapi.space 的破通道
+    // → 用户选 gpt-5.4 却报 cli_key=claude 的 502
+    const xiaomuForcedEnv: Record<string, string> = {}
+    try {
+      const configDir =
+        process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.xiaomu-ai')
+      for (const p of [
+        path.join(configDir, 'settings.json'),
+        path.join(configDir, 'cc-haha', 'settings.json'),
+      ]) {
+        try {
+          const raw = fs.readFileSync(p, 'utf-8')
+          const parsed = JSON.parse(raw) as { env?: Record<string, string> }
+          if (parsed.env) {
+            for (const [k, v] of Object.entries(parsed.env)) {
+              if (typeof v === 'string' && v) xiaomuForcedEnv[k] = v
+            }
+          }
+        } catch { /* skip */ }
+      }
+    } catch { /* skip */ }
+    // 兜底：任何情况下子任务都走 sonnet（保证有通道）
+    if (!xiaomuForcedEnv.ANTHROPIC_SMALL_FAST_MODEL) {
+      xiaomuForcedEnv.ANTHROPIC_SMALL_FAST_MODEL =
+        xiaomuForcedEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL
+        || xiaomuForcedEnv.ANTHROPIC_MODEL
+        || 'gpt-5.4'
+    }
+    if (!xiaomuForcedEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL) {
+      xiaomuForcedEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL =
+        xiaomuForcedEnv.ANTHROPIC_SMALL_FAST_MODEL
+        || xiaomuForcedEnv.ANTHROPIC_MODEL
+        || 'gpt-5.4'
+    }
+    if (!xiaomuForcedEnv.ANTHROPIC_DEFAULT_SONNET_MODEL) {
+      xiaomuForcedEnv.ANTHROPIC_DEFAULT_SONNET_MODEL =
+        xiaomuForcedEnv.ANTHROPIC_MODEL || 'gpt-5.4'
+    }
+    if (!xiaomuForcedEnv.ANTHROPIC_DEFAULT_OPUS_MODEL) {
+      xiaomuForcedEnv.ANTHROPIC_DEFAULT_OPUS_MODEL =
+        xiaomuForcedEnv.ANTHROPIC_MODEL || 'gpt-5.4'
+    }
+
     return {
       ...cleanEnv,
+      // Desktop-launched sessions should keep the Claude Desktop identity even
+      // though they use --sdk-url under the hood. Without this, the CLI tags the
+      // session as sdk-cli and some auth/provider code paths stop treating the
+      // host as the source of truth for routing.
+      CLAUDE_CODE_ENTRYPOINT: 'claude-desktop',
+      // Tell the child CLI that provider routing is host-managed. This prevents
+      // later settings merges from redirecting requests away from the provider
+      // env that Desktop injected for the session.
+      CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: '1',
       CLAUDE_CODE_ENABLE_TASKS: '1',
       CALLER_DIR: workDir,
       PWD: workDir,
@@ -521,18 +595,12 @@ export class ConversationService {
       ...(desktopServerUrl
         ? { CC_HAHA_DESKTOP_SERVER_URL: desktopServerUrl }
         : {}),
-      // Tell the CLI entrypoint to skip project .env loading. Provider env
-      // should come from Desktop-managed config or inherited launch env, not
-      // be reintroduced from the repo's .env file.
       CC_HAHA_SKIP_DOTENV: '1',
-      // "官方" 模式 (cc-haha/settings.json 没 provider env) 下,把 CLI 标记为
-      // managed-OAuth,让它忽略外部 ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN
-      // 残留、只走用户 /login 的 OAuth token。自定义 provider 模式绝不能设,
-      // 否则 CLI 会忽略 provider 的 AUTH_TOKEN、错误地走 OAuth 打到第三方
-      // endpoint。详见 src/utils/auth.ts isManagedOAuthContext()。
       ...(this.shouldMarkManagedOAuth()
         ? await this.buildOfficialOAuthEnv()
         : {}),
+      // xiaomu: 最后注入，确保覆盖上面任何 cleanEnv / managed-OAuth 的残留
+      ...xiaomuForcedEnv,
     }
   }
 
@@ -587,6 +655,7 @@ export class ConversationService {
         'ANTHROPIC_DEFAULT_HAIKU_MODEL',
         'ANTHROPIC_DEFAULT_SONNET_MODEL',
         'ANTHROPIC_DEFAULT_OPUS_MODEL',
+        'ANTHROPIC_SMALL_FAST_MODEL',
       ].some((key) => typeof env[key] === 'string' && env[key]!.trim().length > 0)
     } catch {
       return false
@@ -664,7 +733,9 @@ export class ConversationService {
     }
 
     if (/\.(?:[cm]?[jt]s|tsx?)$/i.test(cliCommand)) {
-      return ['bun', cliCommand, ...baseArgs]
+      // xiaomu: 允许通过 CLAUDE_NODE_PATH 指定 node 而不是 bun（我们 ship 的是 node bundle）
+      const runner = process.env.CLAUDE_NODE_PATH || 'bun'
+      return [runner, cliCommand, ...baseArgs]
     }
 
     const cliBaseName = path.basename(cliCommand)

--- a/src/server/services/modelRoutingService.ts
+++ b/src/server/services/modelRoutingService.ts
@@ -1,0 +1,85 @@
+export type ModelRouting = {
+  main: string
+  haiku: string
+  sonnet: string
+  opus: string
+  smallFast: string
+}
+
+type PartialRoutingInput = Record<string, unknown> | Partial<ModelRouting> | null | undefined
+
+function readString(
+  input: PartialRoutingInput,
+  keys: string[],
+): string | undefined {
+  if (!input || typeof input !== 'object') return undefined
+
+  for (const key of keys) {
+    const value = input[key]
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim()
+    }
+  }
+
+  return undefined
+}
+
+export function normalizeModelRouting(
+  input: PartialRoutingInput,
+  fallbackMain: string,
+): ModelRouting {
+  const main = readString(input, ['main', 'mainModel', 'model', 'modelId']) || fallbackMain
+  const haiku = readString(input, ['haiku', 'haikuModel']) || main
+  const sonnet = readString(input, ['sonnet', 'sonnetModel']) || main
+  const opus = readString(input, ['opus', 'opusModel']) || main
+  const smallFast = readString(input, [
+    'smallFast',
+    'small_fast',
+    'smallFastModel',
+    'small_fast_model',
+  ]) || haiku || main
+
+  return {
+    main,
+    haiku: haiku || main,
+    sonnet: sonnet || main,
+    opus: opus || main,
+    smallFast: smallFast || haiku || main,
+  }
+}
+
+export function routingFromProviderModels(models: {
+  main: string
+  haiku: string
+  sonnet: string
+  opus: string
+}): ModelRouting {
+  return normalizeModelRouting(
+    {
+      main: models.main,
+      haiku: models.haiku,
+      sonnet: models.sonnet,
+      opus: models.opus,
+      smallFast: models.haiku,
+    },
+    models.main,
+  )
+}
+
+export function toModelEnv(routing: ModelRouting): Record<string, string> {
+  return {
+    ANTHROPIC_MODEL: routing.main,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: routing.haiku,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: routing.sonnet,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: routing.opus,
+    ANTHROPIC_SMALL_FAST_MODEL: routing.smallFast,
+  }
+}
+
+export function modelEnvMatches(
+  env: Record<string, string | undefined>,
+  routing: ModelRouting,
+): boolean {
+  const expected = toModelEnv(routing)
+  return Object.entries(expected).every(([key, value]) => env[key] === value)
+}

--- a/src/server/services/providerService.ts
+++ b/src/server/services/providerService.ts
@@ -15,6 +15,10 @@ import { anthropicToOpenaiResponses } from '../proxy/transform/anthropicToOpenai
 import { openaiChatToAnthropic } from '../proxy/transform/openaiChatToAnthropic.js'
 import { openaiResponsesToAnthropic } from '../proxy/transform/openaiResponsesToAnthropic.js'
 import type { AnthropicRequest, AnthropicResponse } from '../proxy/transform/types.js'
+import {
+  routingFromProviderModels,
+  toModelEnv,
+} from './modelRoutingService.js'
 import type {
   SavedProvider,
   ProvidersIndex,
@@ -33,6 +37,7 @@ const MANAGED_ENV_KEYS = [
   'ANTHROPIC_DEFAULT_HAIKU_MODEL',
   'ANTHROPIC_DEFAULT_SONNET_MODEL',
   'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_SMALL_FAST_MODEL',
 ] as const
 
 const DEFAULT_INDEX: ProvidersIndex = { activeId: null, providers: [] }
@@ -226,10 +231,7 @@ export class ProviderService {
       ...existingEnv,
       ANTHROPIC_BASE_URL: baseUrl,
       ANTHROPIC_AUTH_TOKEN: needsProxy ? 'proxy-managed' : provider.apiKey,
-      ANTHROPIC_MODEL: provider.models.main,
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: provider.models.haiku,
-      ANTHROPIC_DEFAULT_SONNET_MODEL: provider.models.sonnet,
-      ANTHROPIC_DEFAULT_OPUS_MODEL: provider.models.opus,
+      ...toModelEnv(routingFromProviderModels(provider.models)),
     }
 
     await this.writeSettings(settings)

--- a/src/server/services/settingsSyncService.ts
+++ b/src/server/services/settingsSyncService.ts
@@ -1,0 +1,74 @@
+import * as fs from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+
+type SyncOptions = {
+  fallbackDirName?: string
+  topLevel?: boolean
+  ccHaha?: boolean
+}
+
+function resolveConfigDir(fallbackDirName = '.claude'): string {
+  return process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), fallbackDirName)
+}
+
+function resolveTargets(options?: SyncOptions): string[] {
+  const configDir = resolveConfigDir(options?.fallbackDirName)
+  const topLevel = options?.topLevel ?? true
+  const ccHaha = options?.ccHaha ?? true
+  const targets: string[] = []
+
+  if (topLevel) targets.push(path.join(configDir, 'settings.json'))
+  if (ccHaha) targets.push(path.join(configDir, 'cc-haha', 'settings.json'))
+
+  return targets
+}
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8')
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {}
+    }
+    throw error
+  }
+}
+
+async function writeJsonFile(
+  filePath: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  const tmpFile = `${filePath}.tmp.${Date.now()}`
+
+  try {
+    await fs.writeFile(tmpFile, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+    await fs.rename(tmpFile, filePath)
+  } catch (error) {
+    await fs.unlink(tmpFile).catch(() => {})
+    throw error
+  }
+}
+
+export async function patchSettingsEnv(
+  envPatch: Record<string, string>,
+  options?: SyncOptions,
+): Promise<void> {
+  const targets = resolveTargets(options)
+
+  await Promise.all(
+    targets.map(async (target) => {
+      const settings = await readJsonFile(target)
+      const currentEnv = (settings.env as Record<string, string>) || {}
+
+      settings.env = {
+        ...currentEnv,
+        ...envPatch,
+      }
+
+      await writeJsonFile(target, settings)
+    }),
+  )
+}

--- a/src/server/services/xiaomuModelService.ts
+++ b/src/server/services/xiaomuModelService.ts
@@ -21,6 +21,7 @@ const XIAOMU_CACHE_TTL_MS = 15 * 1000
 
 const DEFAULT_MODELS: XiaomuModel[] = [
   { id: 'gpt-5.4', name: 'GPT-5.4', description: '默认推荐，稳定好用', context: '200k' },
+  { id: 'gpt-5.5', name: 'GPT-5.5', description: 'OpenAI GPT new model', context: '200k' },
   { id: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', description: '长文本和写作表现强', context: '1m' },
   { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', description: '综合均衡，速度快', context: '200k' },
   { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', description: '创作和理解能力强', context: '200k' },
@@ -47,6 +48,7 @@ const REMOTE_VISIBLE_MODEL_KEYS = ['desktop_visible_models', 'desktop_model_whit
 const REMOTE_ORDER_KEYS = ['desktop_model_order', 'desktop_models_order']
 const REMOTE_DEFAULT_MODEL_KEYS = ['desktop_default_model', 'desktop_default_model_id']
 const REMOTE_ROUTING_KEYS = ['desktop_model_routing', 'desktop_models_routing']
+const PINNED_VISIBLE_MODEL_IDS = ['gpt-5.5']
 
 let modelCatalogCache: { at: number; catalog: XiaomuModelCatalog } | null = null
 
@@ -405,7 +407,16 @@ export async function getXiaomuModelCatalog(): Promise<XiaomuModelCatalog> {
 
     const visibleIds = firstStringArray(statusData, REMOTE_VISIBLE_MODEL_KEYS)
     if (visibleIds.length > 0) {
-      models = materializeModelsById(visibleIds, new Map(models.map((model) => [model.id, model])))
+      const pinnedVisibleIds = [...visibleIds]
+      for (const id of PINNED_VISIBLE_MODEL_IDS) {
+        if (!pinnedVisibleIds.includes(id)) pinnedVisibleIds.push(id)
+      }
+      models = materializeModelsById(
+        pinnedVisibleIds,
+        new Map(
+          [...DEFAULT_MODELS, ...pricingModels, ...models].map((model) => [model.id, model]),
+        ),
+      )
       remoteManaged = true
     }
 

--- a/src/server/services/xiaomuModelService.ts
+++ b/src/server/services/xiaomuModelService.ts
@@ -1,0 +1,482 @@
+import { normalizeModelRouting, type ModelRouting } from './modelRoutingService.js'
+
+export type XiaomuModel = {
+  id: string
+  name: string
+  description: string
+  context: string
+}
+
+export type XiaomuModelCatalog = {
+  models: XiaomuModel[]
+  defaultModelId: string
+  providerName: string
+  routingById: Record<string, ModelRouting>
+  remoteManaged: boolean
+}
+
+const AIAPI_STATUS_URL = 'https://aiapi.space/api/status'
+const AIAPI_PRICING_URL = 'https://aiapi.space/api/pricing'
+const XIAOMU_CACHE_TTL_MS = 15 * 1000
+
+const DEFAULT_MODELS: XiaomuModel[] = [
+  { id: 'gpt-5.4', name: 'GPT-5.4', description: '默认推荐，稳定好用', context: '200k' },
+  { id: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', description: '长文本和写作表现强', context: '1m' },
+  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', description: '综合均衡，速度快', context: '200k' },
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', description: '创作和理解能力强', context: '200k' },
+  { id: 'claude-opus-4-7', name: 'Claude Opus 4.7', description: '最新旗舰模型', context: '1m' },
+  { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', description: '响应速度快', context: '200k' },
+  { id: 'gpt-4.5', name: 'GPT-4.5', description: 'OpenAI 上一代强模型', context: '128k' },
+  { id: 'deepseek-v3.2', name: 'DeepSeek V3.2', description: '国产通用强模型', context: '128k' },
+  { id: 'kimi-k2.5', name: 'Kimi K2.5', description: 'Moonshot 长上下文', context: '200k' },
+  { id: 'glm-5', name: 'GLM-5', description: '智谱通用模型', context: '128k' },
+  { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', description: 'MiniMax 通用模型', context: '1m' },
+]
+
+export const DEFAULT_XIAOMU_MODEL_ID = DEFAULT_MODELS[0]!.id
+
+const DEFAULT_MODEL_INDEX = new Map(DEFAULT_MODELS.map((model, index) => [model.id, index]))
+const DEFAULT_MODEL_MAP = new Map(DEFAULT_MODELS.map((model) => [model.id, model]))
+const REMOTE_MODEL_CONFIG_KEYS = [
+  'desktop_models_config',
+  'desktop_model_config',
+  'desktop_models_json',
+  'desktop_models',
+]
+const REMOTE_VISIBLE_MODEL_KEYS = ['desktop_visible_models', 'desktop_model_whitelist']
+const REMOTE_ORDER_KEYS = ['desktop_model_order', 'desktop_models_order']
+const REMOTE_DEFAULT_MODEL_KEYS = ['desktop_default_model', 'desktop_default_model_id']
+const REMOTE_ROUTING_KEYS = ['desktop_model_routing', 'desktop_models_routing']
+
+let modelCatalogCache: { at: number; catalog: XiaomuModelCatalog } | null = null
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value)
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  const trimmed = value.trim()
+  if (!trimmed) return value
+
+  if (
+    (trimmed.startsWith('{') && trimmed.endsWith('}'))
+    || (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    try {
+      return JSON.parse(trimmed)
+    } catch {
+      return value
+    }
+  }
+
+  return value
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function firstString(
+  source: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = readString(source[key])
+    if (value) return value
+  }
+  return undefined
+}
+
+function toStringArray(value: unknown): string[] {
+  const parsed = parseMaybeJson(value)
+
+  if (Array.isArray(parsed)) {
+    return parsed
+      .map((item) => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean)
+  }
+
+  if (typeof parsed === 'string') {
+    return parsed
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+
+  return []
+}
+
+function firstStringArray(
+  source: Record<string, unknown>,
+  keys: string[],
+): string[] {
+  for (const key of keys) {
+    const values = toStringArray(source[key])
+    if (values.length > 0) return values
+  }
+  return []
+}
+
+function prettyModelName(id: string): string {
+  return id
+    .replace(/^claude-/, 'Claude ')
+    .replace(/^gpt-/, 'GPT-')
+    .replace(/^gemini-/, 'Gemini ')
+    .replace(/^deepseek-/, 'DeepSeek ')
+    .replace(/^kimi-/, 'Kimi ')
+    .replace(/^glm-/, 'GLM-')
+    .replace(/-preview$/, ' Preview')
+}
+
+function formatPricingDescription(model: Record<string, unknown>): string {
+  const type = model.quota_type === 0 ? '按量' : '按次'
+  const ratio = model.model_ratio ?? model.ratio ?? 1
+  const completionRatio = model.completion_ratio ?? 1
+  const displayName = readString(model.display_name)
+
+  const parts = [
+    displayName,
+    type,
+    `倍率 ${ratio}${completionRatio !== 1 ? ` / ${completionRatio}` : ''}`,
+  ].filter(Boolean)
+
+  return parts.join(' · ')
+}
+
+function buildFallbackModel(id: string): XiaomuModel {
+  const fallback = DEFAULT_MODEL_MAP.get(id)
+  if (fallback) return fallback
+
+  return {
+    id,
+    name: prettyModelName(id),
+    description: '',
+    context: '',
+  }
+}
+
+function dedupeModels(models: XiaomuModel[]): XiaomuModel[] {
+  const seen = new Set<string>()
+  const deduped: XiaomuModel[] = []
+
+  for (const model of models) {
+    if (seen.has(model.id)) continue
+    seen.add(model.id)
+    deduped.push(model)
+  }
+
+  return deduped
+}
+
+function sortModels(models: XiaomuModel[]): XiaomuModel[] {
+  return [...models].sort((a, b) => {
+    const aIndex = DEFAULT_MODEL_INDEX.get(a.id)
+    const bIndex = DEFAULT_MODEL_INDEX.get(b.id)
+
+    if (aIndex != null && bIndex != null) return aIndex - bIndex
+    if (aIndex != null) return -1
+    if (bIndex != null) return 1
+
+    return a.id.localeCompare(b.id)
+  })
+}
+
+function materializeModelsById(
+  ids: string[],
+  knownModels: Map<string, XiaomuModel>,
+): XiaomuModel[] {
+  return ids.map((id) => knownModels.get(id) ?? buildFallbackModel(id))
+}
+
+function readRemoteConfigObject(statusData: Record<string, unknown>): unknown {
+  for (const key of REMOTE_MODEL_CONFIG_KEYS) {
+    const parsed = parseMaybeJson(statusData[key])
+    if (Array.isArray(parsed) || isObject(parsed)) {
+      return parsed
+    }
+  }
+  return null
+}
+
+function normalizeRemoteModelEntry(
+  entry: unknown,
+  pricingById: Map<string, XiaomuModel>,
+): { model: XiaomuModel; routing: ModelRouting } | null {
+  if (typeof entry === 'string') {
+    const id = entry.trim()
+    if (!id) return null
+    return {
+      model: pricingById.get(id) ?? buildFallbackModel(id),
+      routing: normalizeModelRouting(undefined, id),
+    }
+  }
+
+  if (!isObject(entry)) return null
+  if (entry.enabled === false || entry.visible === false || entry.disabled === true) {
+    return null
+  }
+
+  const id = firstString(entry, ['id', 'modelId', 'model', 'model_name'])
+  if (!id) return null
+
+  const pricingModel = pricingById.get(id)
+  const nestedRouting = parseMaybeJson(entry.routing)
+  const routing = normalizeModelRouting(
+    isObject(nestedRouting) ? { ...nestedRouting, ...entry } : entry,
+    id,
+  )
+
+  return {
+    model: {
+      id,
+      name:
+        firstString(entry, ['name', 'displayName', 'display_name', 'label'])
+        || pricingModel?.name
+        || prettyModelName(id),
+      description:
+        firstString(entry, ['description', 'desc', 'subtitle'])
+        || pricingModel?.description
+        || '',
+      context:
+        firstString(entry, ['context', 'contextWindow', 'context_window'])
+        || pricingModel?.context
+        || '',
+    },
+    routing,
+  }
+}
+
+function parseRoutingMap(value: unknown): Record<string, ModelRouting> {
+  const parsed = parseMaybeJson(value)
+  if (!isObject(parsed)) return {}
+
+  const routingById: Record<string, ModelRouting> = {}
+  for (const [modelId, routing] of Object.entries(parsed)) {
+    if (!modelId.trim()) continue
+    routingById[modelId] = normalizeModelRouting(routing, modelId)
+  }
+  return routingById
+}
+
+function buildCatalogFromRemoteConfig(
+  remoteConfig: unknown,
+  pricingById: Map<string, XiaomuModel>,
+): {
+  models?: XiaomuModel[]
+  defaultModelId?: string
+  providerName?: string
+  routingById: Record<string, ModelRouting>
+  hasRemoteControl: boolean
+} {
+  if (Array.isArray(remoteConfig)) {
+    const entries = remoteConfig
+      .map((entry) => normalizeRemoteModelEntry(entry, pricingById))
+      .filter((entry): entry is { model: XiaomuModel; routing: ModelRouting } => entry != null)
+
+    return {
+      models: entries.map((entry) => entry.model),
+      routingById: Object.fromEntries(entries.map((entry) => [entry.model.id, entry.routing])),
+      hasRemoteControl: entries.length > 0,
+    }
+  }
+
+  if (!isObject(remoteConfig)) {
+    return { routingById: {}, hasRemoteControl: false }
+  }
+
+  const rawModels = ['models', 'visibleModels', 'items', 'list']
+    .map((key) => parseMaybeJson(remoteConfig[key]))
+    .find((value) => Array.isArray(value))
+  const visibleIds = firstStringArray(remoteConfig, ['visibleModelIds', 'modelIds'])
+  const orderIds = firstStringArray(remoteConfig, ['order', 'modelOrder'])
+  const externalRouting = parseRoutingMap(
+    remoteConfig.routing ?? remoteConfig.modelRouting,
+  )
+
+  let models: XiaomuModel[] | undefined
+  const routingById: Record<string, ModelRouting> = { ...externalRouting }
+
+  if (Array.isArray(rawModels)) {
+    const entries = rawModels
+      .map((entry) => normalizeRemoteModelEntry(entry, pricingById))
+      .filter((entry): entry is { model: XiaomuModel; routing: ModelRouting } => entry != null)
+
+    models = entries.map((entry) => entry.model)
+    for (const entry of entries) {
+      routingById[entry.model.id] = entry.routing
+    }
+  } else if (visibleIds.length > 0) {
+    models = materializeModelsById(visibleIds, pricingById)
+  }
+
+  if (models && orderIds.length > 0) {
+    const modelMap = new Map(models.map((model) => [model.id, model]))
+    const ordered = materializeModelsById(orderIds, modelMap)
+    const rest = models.filter((model) => !orderIds.includes(model.id))
+    models = dedupeModels([...ordered, ...rest])
+  }
+
+  return {
+    models,
+    defaultModelId: firstString(remoteConfig, ['defaultModel', 'defaultModelId']),
+    providerName: firstString(remoteConfig, ['providerName', 'systemName']),
+    routingById,
+    hasRemoteControl:
+      !!models
+      || visibleIds.length > 0
+      || orderIds.length > 0
+      || !!firstString(remoteConfig, ['defaultModel', 'defaultModelId'])
+      || Object.keys(externalRouting).length > 0,
+  }
+}
+
+async function fetchStatusData(): Promise<Record<string, unknown>> {
+  const response = await fetch(AIAPI_STATUS_URL, {
+    cache: 'no-store',
+    signal: AbortSignal.timeout(4000),
+    headers: { 'User-Agent': 'xiaomu-desktop/8.0' },
+  })
+  if (!response.ok) throw new Error(`status HTTP ${response.status}`)
+  const payload = (await response.json()) as { data?: Record<string, unknown> }
+  return isObject(payload.data) ? payload.data : {}
+}
+
+async function fetchPricingModels(): Promise<XiaomuModel[]> {
+  const response = await fetch(AIAPI_PRICING_URL, {
+    cache: 'no-store',
+    signal: AbortSignal.timeout(6000),
+    headers: { 'User-Agent': 'xiaomu-desktop/8.0' },
+  })
+  if (!response.ok) throw new Error(`pricing HTTP ${response.status}`)
+
+  const payload = (await response.json()) as { success?: boolean; data?: unknown[] }
+  if (!payload.success || !Array.isArray(payload.data)) {
+    throw new Error('invalid pricing response')
+  }
+
+  return dedupeModels(
+    payload.data
+      .filter((item): item is Record<string, unknown> => isObject(item))
+      .map((item) => {
+        const id = readString(item.model_name)
+        if (!id) return null
+        const fallback = DEFAULT_MODEL_MAP.get(id)
+        return {
+          id,
+          name: fallback?.name ?? prettyModelName(id),
+          description: formatPricingDescription(item),
+          context: fallback?.context ?? '',
+        }
+      })
+      .filter((item): item is XiaomuModel => item != null),
+  )
+}
+
+export async function getXiaomuModelCatalog(): Promise<XiaomuModelCatalog> {
+  if (modelCatalogCache && Date.now() - modelCatalogCache.at < XIAOMU_CACHE_TTL_MS) {
+    return modelCatalogCache.catalog
+  }
+
+  try {
+    const [pricingResult, statusResult] = await Promise.allSettled([
+      fetchPricingModels(),
+      fetchStatusData(),
+    ])
+
+    const pricingModels =
+      pricingResult.status === 'fulfilled' && pricingResult.value.length > 0
+        ? pricingResult.value
+        : DEFAULT_MODELS
+    const pricingById = new Map(pricingModels.map((model) => [model.id, model]))
+    const statusData = statusResult.status === 'fulfilled' ? statusResult.value : {}
+
+    let models = sortModels(pricingModels)
+    let remoteManaged = false
+
+    const remoteConfig = readRemoteConfigObject(statusData)
+    const remoteConfigResult = buildCatalogFromRemoteConfig(remoteConfig, pricingById)
+    if (remoteConfigResult.hasRemoteControl) {
+      remoteManaged = true
+      if (remoteConfigResult.models && remoteConfigResult.models.length > 0) {
+        models = dedupeModels(remoteConfigResult.models)
+      }
+    }
+
+    const visibleIds = firstStringArray(statusData, REMOTE_VISIBLE_MODEL_KEYS)
+    if (visibleIds.length > 0) {
+      models = materializeModelsById(visibleIds, new Map(models.map((model) => [model.id, model])))
+      remoteManaged = true
+    }
+
+    const orderIds = firstStringArray(statusData, REMOTE_ORDER_KEYS)
+    if (orderIds.length > 0) {
+      const modelMap = new Map(models.map((model) => [model.id, model]))
+      const ordered = materializeModelsById(orderIds, modelMap)
+      const rest = models.filter((model) => !orderIds.includes(model.id))
+      models = dedupeModels([...ordered, ...rest])
+      remoteManaged = true
+    }
+
+    if (models.length === 0) {
+      models = DEFAULT_MODELS
+    }
+
+    const routingById: Record<string, ModelRouting> = {}
+    for (const model of models) {
+      routingById[model.id] = normalizeModelRouting(undefined, model.id)
+    }
+    Object.assign(
+      routingById,
+      parseRoutingMap(
+        REMOTE_ROUTING_KEYS
+          .map((key) => statusData[key])
+          .find((value) => value != null),
+      ),
+      remoteConfigResult.routingById,
+    )
+
+    const requestedDefault =
+      remoteConfigResult.defaultModelId
+      || firstString(statusData, REMOTE_DEFAULT_MODEL_KEYS)
+      || DEFAULT_XIAOMU_MODEL_ID
+    const defaultModelId = models.some((model) => model.id === requestedDefault)
+      ? requestedDefault
+      : (models[0]?.id ?? DEFAULT_XIAOMU_MODEL_ID)
+
+    const catalog: XiaomuModelCatalog = {
+      models,
+      defaultModelId,
+      providerName: remoteConfigResult.providerName || firstString(statusData, ['system_name']) || '丸美小沐',
+      routingById,
+      remoteManaged,
+    }
+
+    modelCatalogCache = {
+      at: Date.now(),
+      catalog,
+    }
+
+    return catalog
+  } catch (error) {
+    console.warn('[models] failed to load xiaomu model catalog, using fallback:', error)
+    const catalog: XiaomuModelCatalog = {
+      models: DEFAULT_MODELS,
+      defaultModelId: DEFAULT_XIAOMU_MODEL_ID,
+      providerName: '丸美小沐',
+      routingById: Object.fromEntries(
+        DEFAULT_MODELS.map((model) => [model.id, normalizeModelRouting(undefined, model.id)]),
+      ),
+      remoteManaged: false,
+    }
+    modelCatalogCache = {
+      at: Date.now(),
+      catalog,
+    }
+    return catalog
+  }
+}
+
+export function resetXiaomuModelCatalogCache(): void {
+  modelCatalogCache = null
+}

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -878,6 +878,7 @@ async function getRuntimeSettings(): Promise<{
   permissionMode?: string
   model?: string
   effort?: string
+  runtimeRevision?: number
 }> {
   const userSettings = await settingsService.getUserSettings()
   const modelContext =
@@ -929,6 +930,7 @@ async function getRuntimeSettings(): Promise<{
     permissionMode: await settingsService.getPermissionMode().catch(() => undefined),
     model,
     effort,
+    runtimeRevision: conversationService.getRuntimeRevision(),
   }
 }
 

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -18,9 +18,13 @@ import { sessionService } from '../services/sessionService.js'
 import { SettingsService } from '../services/settingsService.js'
 import { ProviderService } from '../services/providerService.js'
 import { deriveTitle, generateTitle, saveAiTitle } from '../services/titleService.js'
+import { normalizeModelRouting, toModelEnv } from '../services/modelRoutingService.js'
+import { patchSettingsEnv } from '../services/settingsSyncService.js'
+import { getXiaomuModelCatalog } from '../services/xiaomuModelService.js'
 
 const settingsService = new SettingsService()
 const providerService = new ProviderService()
+const XIAOMU_CONFIG_FALLBACK_DIR = '.xiaomu-ai'
 
 /**
  * Cache slash commands from CLI init messages, keyed by sessionId.
@@ -193,12 +197,20 @@ async function handleUserMessage(
   // Send thinking status
   sendMessage(ws, { type: 'status', state: 'thinking', verb: 'Thinking' })
 
+  const runtimeSettings = await getRuntimeSettings()
+  const hasSession = conversationService.hasSession(sessionId)
+  const shouldRestartForRuntime =
+    hasSession && conversationService.needsRestartForRuntimeOptions(sessionId, runtimeSettings)
+
   // 启动 CLI 子进程（如果还没有）
-  if (!conversationService.hasSession(sessionId)) {
+  if (!hasSession || shouldRestartForRuntime) {
     try {
       // Resolve the session's actual working directory
       try {
-        const resolved = await sessionService.getSessionWorkDir(sessionId)
+        const resolved =
+          shouldRestartForRuntime
+            ? conversationService.getSessionWorkDir(sessionId) || await sessionService.getSessionWorkDir(sessionId)
+            : await sessionService.getSessionWorkDir(sessionId)
         if (resolved) workDir = resolved
         console.log(
           `[WS] handleUserMessage: sessionId=${sessionId}, resolved workDir=${JSON.stringify(
@@ -213,7 +225,10 @@ async function handleUserMessage(
           }`,
         )
       }
-      const runtimeSettings = await getRuntimeSettings()
+      if (shouldRestartForRuntime) {
+        console.log(`[WS] Restarting CLI for ${sessionId} because runtime model/settings changed`)
+        conversationService.stopSession(sessionId)
+      }
       const sdkUrl =
         `ws://${ws.data.serverHost}:${ws.data.serverPort}/sdk/${sessionId}` +
         `?token=${encodeURIComponent(crypto.randomUUID())}`
@@ -456,10 +471,12 @@ function triggerTitleGeneration(ws: ServerWebSocket<WebSocketData>, sessionId: s
  */
 type SessionStreamState = {
   hasReceivedStreamEvents: boolean
+  hasReceivedTextDelta: boolean
+  hasReceivedThinkingDelta: boolean
   activeBlockTypes: Map<number, 'text' | 'tool_use'>
   activeToolBlocks: Map<number, { toolName: string; toolUseId: string; inputJson: string }>
   /** Tool blocks whose input JSON failed to parse in content_block_stop.
-   *  The assistant message carries the complete input — defer to that. */
+   *  The assistant message carries the complete input - defer to that. */
   pendingToolBlocks: Map<string, { toolName: string; toolUseId: string; parentToolUseId?: string }>
 }
 
@@ -470,6 +487,8 @@ function getStreamState(sessionId: string): SessionStreamState {
   if (!state) {
     state = {
       hasReceivedStreamEvents: false,
+      hasReceivedTextDelta: false,
+      hasReceivedThinkingDelta: false,
       activeBlockTypes: new Map(),
       activeToolBlocks: new Map(),
       pendingToolBlocks: new Map(),
@@ -484,7 +503,14 @@ function cleanupStreamState(sessionId: string) {
   sessionStreamStates.delete(sessionId)
 }
 
-function translateCliMessage(cliMsg: any, sessionId: string): ServerMessage[] {
+function resetStreamTurnState(streamState: SessionStreamState): void {
+  streamState.hasReceivedStreamEvents = false
+  streamState.hasReceivedTextDelta = false
+  streamState.hasReceivedThinkingDelta = false
+  streamState.pendingToolBlocks.clear()
+}
+
+export function translateCliMessage(cliMsg: any, sessionId: string): ServerMessage[] {
   const streamState = getStreamState(sessionId)
   switch (cliMsg.type) {
     case 'assistant': {
@@ -496,13 +522,33 @@ function translateCliMessage(cliMsg: any, sessionId: string): ServerMessage[] {
         }]
       }
 
-      // If we already received stream_events, text/thinking were already sent.
-      // Only extract tool_use blocks (stream_event's content_block_stop lacks complete tool info).
+      // If we already received stream_events, text/thinking were usually already
+      // sent. Some providers only emit partial stream events, so fall back to
+      // the final assistant payload when no renderable text/thinking delta was
+      // actually forwarded to the frontend.
       if (cliMsg.message?.content && Array.isArray(cliMsg.message.content)) {
         const messages: ServerMessage[] = []
 
         for (const block of cliMsg.message.content) {
           if (streamState.hasReceivedStreamEvents) {
+            if (
+              block.type === 'thinking' &&
+              block.thinking &&
+              !streamState.hasReceivedThinkingDelta
+            ) {
+              messages.push({ type: 'thinking', text: block.thinking })
+              continue
+            }
+
+            if (
+              block.type === 'text' &&
+              block.text &&
+              !streamState.hasReceivedTextDelta
+            ) {
+              messages.push({ type: 'content_start', blockType: 'text' })
+              messages.push({ type: 'content_delta', text: block.text })
+              continue
+            }
             // Stream events handled most blocks — but any tool_use whose
             // input JSON failed to parse in content_block_stop was deferred.
             // Emit those now with the complete input from the assistant message.
@@ -540,8 +586,7 @@ function translateCliMessage(cliMsg: any, sessionId: string): ServerMessage[] {
         }
 
         // Reset flags for next turn
-        streamState.hasReceivedStreamEvents = false
-        streamState.pendingToolBlocks.clear()
+        resetStreamTurnState(streamState)
         return messages
       }
       return []
@@ -615,6 +660,7 @@ function translateCliMessage(cliMsg: any, sessionId: string): ServerMessage[] {
           if (!delta) return []
 
           if (delta.type === 'text_delta' && delta.text) {
+            streamState.hasReceivedTextDelta = true
             return [{ type: 'content_delta', text: delta.text }]
           }
           if (delta.type === 'input_json_delta' && delta.partial_json) {
@@ -625,6 +671,7 @@ function translateCliMessage(cliMsg: any, sessionId: string): ServerMessage[] {
             return [{ type: 'content_delta', toolInput: delta.partial_json }]
           }
           if (delta.type === 'thinking_delta' && delta.thinking) {
+            streamState.hasReceivedThinkingDelta = true
             return [{ type: 'thinking', text: delta.thinking }]
           }
           return []
@@ -709,6 +756,7 @@ function translateCliMessage(cliMsg: any, sessionId: string): ServerMessage[] {
         input_tokens: cliMsg.usage?.input_tokens || 0,
         output_tokens: cliMsg.usage?.output_tokens || 0,
       }
+      resetStreamTurnState(streamState)
 
       if (cliMsg.is_error) {
         // If the user requested stop, this "error" is just the interrupt
@@ -857,10 +905,23 @@ async function getRuntimeSettings(): Promise<{
     }
   } else {
     // No provider — pass model normally
-    const baseModel =
+    let baseModel =
       typeof userSettings.model === 'string' && userSettings.model.trim()
         ? userSettings.model
         : undefined
+    if (!baseModel) {
+      const catalog = await getXiaomuModelCatalog()
+      baseModel = catalog.defaultModelId
+      const routing =
+        catalog.routingById[baseModel] || normalizeModelRouting(undefined, baseModel)
+      await patchSettingsEnv(toModelEnv(routing), {
+        fallbackDirName: XIAOMU_CONFIG_FALLBACK_DIR,
+        topLevel: true,
+        ccHaha: true,
+      }).catch((error) => {
+        console.warn('[WS] failed to sync remote default model routing:', error)
+      })
+    }
     model = baseModel ? (modelContext ? `${baseModel}:${modelContext}` : baseModel) : undefined
   }
 


### PR DESCRIPTION
Adds GPT-5.5 to the desktop model list and keeps it visible even when the remote desktop whitelist omits it. Also includes the runtime refresh fixes from the local branch so model setting changes take effect without stale runtime options.