### PR TITLE
fix: prevent ANTHROPIC_BASE_URL loss causing 403 for third-party providers

### DIFF
--- a/src/server/services/conversationService.ts
+++ b/src/server/services/conversationService.ts
@@ -552,10 +552,30 @@ export class ConversationService {
       }
     }
 
-    const explicitProviderEnv =
+    let explicitProviderEnv =
       typeof options?.providerId === 'string'
         ? await this.providerService.getProviderRuntimeEnv(options.providerId)
         : null
+
+    // When no explicit providerId is passed but inherited env was stripped
+    // (because providers.json exists), read the active provider's env from
+    // cc-haha/settings.json so the subprocess always has ANTHROPIC_BASE_URL.
+    if (!explicitProviderEnv && this.shouldStripInheritedProviderEnv(options?.providerId)) {
+      try {
+        const settingsPath = path.join(
+          process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude'),
+          'cc-haha', 'settings.json',
+        )
+        const raw = fs.readFileSync(settingsPath, 'utf-8')
+        const parsed = JSON.parse(raw) as { env?: Record<string, string> }
+        if (parsed.env && Object.keys(parsed.env).length > 0) {
+          explicitProviderEnv = parsed.env
+        }
+      } catch {
+        // File missing or unreadable — subprocess will fall back to its own
+        // applySafeConfigEnvironmentVariables() at startup
+      }
+    }
 
     return {
       ...cleanEnv,

--- a/src/utils/managedEnv.ts
+++ b/src/utils/managedEnv.ts
@@ -98,14 +98,25 @@ function filterSettingsEnv(
  * contains ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, model defaults, etc.
  * Returns an empty object if the file doesn't exist or is invalid.
  */
+// Cache the last successfully read cc-haha env so that a transient read
+// failure (file locked, race condition during atomic write) does not wipe
+// ANTHROPIC_BASE_URL / ANTHROPIC_API_KEY from process.env on hot-reload.
+let lastKnownCcHahaEnv: Record<string, string> = {}
+
 function getCcHahaSettingsEnv(): Record<string, string> {
   try {
     const ccHahaSettings = join(getClaudeConfigHomeDir(), 'cc-haha', 'settings.json')
     const raw = readFileSync(ccHahaSettings, 'utf-8')
     const parsed = JSON.parse(raw) as { env?: Record<string, string> }
-    return parsed.env ?? {}
+    const env = parsed.env ?? {}
+    if (Object.keys(env).length > 0) {
+      lastKnownCcHahaEnv = env
+    }
+    return lastKnownCcHahaEnv
   } catch {
-    return {}
+    // File missing / locked / corrupt — return last known good values
+    // instead of empty object, to avoid wiping provider config from process.env
+    return lastKnownCcHahaEnv
   }
 }
 


### PR DESCRIPTION
## Summary

- `getCcHahaSettingsEnv()` now caches last known good values; transient read failures (file locked, Windows atomic write race) no longer wipe `ANTHROPIC_BASE_URL` from `process.env` during settings hot-reload
- `buildChildEnv()` now reads `cc-haha/settings.json` directly when inherited env is stripped but no explicit `providerId` is passed, ensuring CLI subprocesses always have `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY`

## Problem

Third-party provider users on the desktop app (especially Windows) experienced intermittent 403 errors with Anthropic's `"Request not allowed"` response. This happened because requests were sent to `api.anthropic.com` instead of the configured third-party API endpoint.

### Root cause 1: `getCcHahaSettingsEnv()` silent failure

`src/utils/managedEnv.ts` — `getCcHahaSettingsEnv()` returned `{}` on any read error. During settings hot-reload (triggered by `~/.claude/settings.json` changes), this caused `ANTHROPIC_BASE_URL` to be lost from `process.env`.

### Root cause 2: `buildChildEnv()` missing provider env

`src/server/services/conversationService.ts` — When `shouldStripInheritedProviderEnv()` returned `true` (because `providers.json` existed), all `ANTHROPIC_*` vars were stripped from the inherited env. But `explicitProviderEnv` was `null` when no `providerId` was passed, so subprocesses started without `ANTHROPIC_BASE_URL`, falling back to Anthropic's API.

## Test plan

- [x] Configure a third-party provider in the desktop app
- [ ] Start a new conversation — verify requests go to the third-party API
- [ ] Wait for a settings hot-reload (edit `~/.claude/settings.json`)
- [ ] Continue the conversation — verify no 403 errors
- [ ] On Windows: create multiple conversations rapidly — verify all get correct env

🤖 Generated with [Claude Code](https://claude.com/claude-code)