### PR TITLE
fix(adapters): harden credential file storage in pairing.ts

### DIFF
--- a/adapters/common/pairing.ts
+++ b/adapters/common/pairing.ts
@@ -58,9 +58,9 @@ function readConfigFile(): Record<string, any> {
 function writeConfigFile(data: Record<string, any>): void {
   const filePath = getConfigPath()
   const dir = path.dirname(filePath)
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-  const tmp = `${filePath}.tmp.${Date.now()}`
-  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const tmp = `${filePath}.tmp.${crypto.randomBytes(8).toString('hex')}`
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 })
   fs.renameSync(tmp, filePath)
 }
 


### PR DESCRIPTION
## Summary
- Use `crypto.randomBytes` for temp file name to prevent TOCTOU symlink race
- Enforce `0o600` on `adapters.json` to prevent credential exposure via permissive umask  
- Enforce `0o700` on `~/.claude/` config directory

## Context
`adapters.json` stores sensitive credentials including Feishu `appSecret`, Telegram `botToken`, and encryption keys. Three issues in the atomic write path:

1. **Predictable temp filename** — `Date.now()` makes the temp file predictable, enabling a local attacker to create a symlink and redirect the write
2. **Config file permissions unset** — `writeFileSync` defaults to umask-dependent permissions, potentially exposing `appSecret` and `botToken` to other users on shared systems
3. **Config directory permissions unset** — `mkdirSync` without explicit mode, same umask leakage

## Test plan
- [ ] `adapters.json` is created with `0600` permissions after `tryPair()` succeeds  
- [ ] `~/.claude/` directory is created with `0700` permissions
- [ ] Existing pairing code path works correctly (temp file + atomic rename)