### PR TITLE
Probe PR quality CLI-core policy

### DIFF
--- a/src/commands/__pr_quality_probe__.ts
+++ b/src/commands/__pr_quality_probe__.ts
@@ -1,0 +1,1 @@
+export const prQualityProbe = true


### PR DESCRIPTION
## Summary
- Temporary probe PR to verify PR quality policy behavior before merging the workflow branch.
- Intentionally touches a CLI-core path and should be blocked by change-policy.

## Expected Result
- PR Triage adds `area:cli-core` and `needs-maintainer-approval`.
- PR Quality `change-policy` fails without `allow-cli-core-change`.

@dosubot review this PR for changed-area risk, missing tests, docs impact, desktop startup risk, and CLI core impact.