### PR TITLE
feat: add wx-backup-decrypt skill + optimization & bugfix

### DIFF
--- a/.claude/skills/wx-backup-decrypt/LICENSE
+++ b/.claude/skills/wx-backup-decrypt/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 duyufansh2008
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/wx-backup-decrypt/README.md
+++ b/.claude/skills/wx-backup-decrypt/README.md
@@ -1,0 +1,108 @@
+# wx-backup-decrypt
+
+微信备份数据库（.xb）解密工具，适用于 Claude Code。
+
+通过已知明文攻击自动发现加密密钥，解密和提取 NAS/Android 微信备份数据库中的聊天数据。
+
+## 安装
+
+```bash
+# 在你的 Claude Code 项目目录下
+claude skill add https://github.com/duyufansh2008/wx-backup-decrypt
+```
+
+或手动安装：
+1. 将此仓库克隆到 `.claude/skills/wx-backup-decrypt/`
+2. 完成 — Claude Code 会自动识别
+
+## 快速开始
+
+```
+/wx-backup-decrypt /path/to/wxid_xxx.xb
+```
+
+工具会自动：
+1. 分析数据库结构
+2. 通过已知明文攻击发现加密密钥
+3. 解密所有消息、好友和群聊
+4. 导出为 JSON/TXT 格式
+
+## 独立使用
+
+```bash
+python tools/decrypt.py --db /path/to/database.xb --output ./decrypted
+```
+
+### 参数
+
+| 参数 | 说明 |
+|------|------|
+| `--db` | .xb 数据库文件路径（必填） |
+| `--imei` | 手机 IMEI 号（用于 IMEI 密钥推导） |
+| `--uin` | 微信 UIN（与 IMEI 配合使用） |
+| `--output` | 输出目录（默认：`./wx_decrypted`） |
+| `--exclude-keywords` | 要排除的群聊名称关键词（如 `--exclude-keywords 关键词1 关键词2`） |
+
+## 工作原理
+
+### 加密密钥发现
+
+微信 NAS 备份数据库（`.xb` 文件）对 `wx_chat.content` 字段使用了简单的 XOR 加密。密钥发现过程：
+
+1. **已知明文攻击**：`wx_backup_history.display` 字段通常以**明文**存储每个会话的最后一条消息
+2. 将明文与同一时间戳和会话的加密内容匹配
+3. 逐字节 XOR 恢复密钥
+4. 用多组数据验证 — 密钥通常是单字节常量
+
+### 注意事项
+
+- **并非所有字段都加密了！** `wx_friend.nickname`、`wx_group.nickName` 等字段可能是明文，而 `wx_chat.content` 是 XOR 加密的
+- 不要盲目对所有字段解密 — 先检测每个字段
+- IMEI 推导方法（`MD5(IMEI + UIN)[:7]`）作为备用方案可用
+
+### 数据库结构
+
+| 表 | 内容 | 加密情况 |
+|---|------|---------|
+| `wx_chat` | 消息 | content：XOR 加密 |
+| `wx_friend` | 联系人 | nickname/remark：视情况（通常明文） |
+| `wx_group` | 群聊 | nickName：视情况（通常明文） |
+| `wx_backup_history` | 备份记录 | display：**明文**（攻击的关键！） |
+| `wx_config` | 配置 | 明文 |
+| `wx_stat` | 统计 | 明文 |
+
+### 消息类型
+
+| msg_type | 说明 |
+|----------|------|
+| 1 | 文本消息 |
+| 3 | 图片 |
+| 34 | 语音 |
+| 43 | 视频 |
+| 47 | 表情 |
+| 49 | 链接/小程序 |
+| 50 | 视频通话 |
+| 10000 | 系统消息 |
+| 10002 | 系统通知 |
+
+## 输出文件
+
+| 文件 | 内容 |
+|------|------|
+| `user_messages.json` | 用户发送的文本消息（已过滤） |
+| `user_messages.txt` | 纯文本格式：`[时间戳] 消息内容` |
+| `all_user_messages.json` | 用户所有类型消息（已过滤） |
+| `all_text_messages.json` | 所有人发的文本消息（已过滤） |
+| `friends.json` | 好友列表 |
+| `groups.json` | 群聊列表 |
+| `decrypt_stats.json` | 解密统计 |
+
+## 兼容性
+
+- 测试环境：群晖/QNAP NAS 微信备份（.xb）格式
+- Python：3.7+
+- 无外部依赖（仅使用标准库：sqlite3, hashlib, json, os, argparse, collections, datetime）
+
+## 许可证
+
+MIT

--- a/.claude/skills/wx-backup-decrypt/SKILL.md
+++ b/.claude/skills/wx-backup-decrypt/SKILL.md
@@ -164,7 +164,7 @@ If the key varies per byte, try:
 ### 4.1 Decrypt messages
 
 ```python
-XOR_KEY = 0x00  # Replace with discovered key
+XOR_KEY = discovered_key  # Auto-discovered via known-plaintext attack
 
 def decrypt_content(content_hex):
     if not content_hex or len(content_hex) % 2 != 0:

--- a/.claude/skills/wx-backup-decrypt/SKILL.md
+++ b/.claude/skills/wx-backup-decrypt/SKILL.md
@@ -1,299 +1,116 @@
 ---
 name: wx-backup-decrypt
 description: "Decrypt and extract WeChat backup database (.xb files) from NAS/Android backups. Handles XOR-encrypted content fields, friend/group metadata, and exports all messages. | 解密和提取微信备份数据库（.xb文件），处理加密内容字段，导出全部消息。"
-argument-hint: "[database-path] [--imei IMEI] [--output OUTPUT_DIR]"
-version: "1.0.0"
+argument-hint: "[database-path] [--imei IMEI] [--output OUTPUT_DIR] [--exclude-keywords KW1 KW2]"
+version: "1.1.0"
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash
 ---
 
-> **Language / 语言**: This skill supports both English and Chinese. Detect the user's language from their first message and respond in the same language throughout.
+> **Language / 语言**: Detect user's language from first message, respond in same language throughout.
 
 # WeChat Backup Database Decryptor
 
-## Overview
+## Trigger
 
-WeChat backup databases (`.xb` files) on NAS devices or Android backup tools contain encrypted message content. This skill provides a complete pipeline to:
+Activate when user:
+- Runs `/wx-backup-decrypt`
+- Mentions: 解密微信备份数据, decrypt wechat backup, 微信聊天记录解密
+- Points to a `.xb` file or WeChat backup directory
 
-1. **Identify** the database structure and encryption method
-2. **Decrypt** all message content using known-plaintext attack
-3. **Export** messages, friends, and groups in multiple formats
-4. **Filter** out unwanted sessions (e.g., gaming service groups)
+## Flow
 
-## Trigger Conditions
-
-Activate when the user says any of the following:
-- `/wx-backup-decrypt`
-- "解密微信备份数据"
-- "decrypt wechat backup"
-- "微信聊天记录解密"
-- Points to a `.xb` file or directory containing WeChat backup data
-
----
-
-## Step 1: Database Discovery & Schema Analysis
-
-### 1.1 Locate the database
-
-Search for `.xb` files in the user-provided path:
+### 1. Locate database
 
 ```bash
 find {path} -name "*.xb" -type f 2>/dev/null
 ```
 
-### 1.2 Analyze schema
+If directory provided, also check for `.xb` files directly inside it.
 
-```python
-import sqlite3
+### 2. Decrypt using the tool
 
-conn = sqlite3.connect(db_path)
-cursor = conn.cursor()
+Run the bundled Python script:
 
-# List tables
-cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-tables = cursor.fetchall()
-
-# Get table schemas
-for table in tables:
-    cursor.execute(f"PRAGMA table_info([{table[0]}])")
-    columns = cursor.fetchall()
-    # Print column info
-
-# Count rows per table
-for table in tables:
-    cursor.execute(f"SELECT COUNT(*) FROM [{table[0]}]")
-    count = cursor.fetchone()[0]
+```bash
+python3 .claude/skills/wx-backup-decrypt/tools/decrypt.py \
+  --db {db_path} \
+  --output {output_dir} \
+  [--wxid {wxid}] \
+  [--imei {imei}] [--uin {uin}] \
+  [--exclude-keywords {kw1} {kw2}]
 ```
 
-### 1.3 Identify key tables
+**Parameters:**
+| Param | Required | Description |
+|-------|----------|-------------|
+| `--db` | Yes | Path to .xb database |
+| `--output` | No | Output directory (default: `./wx_decrypted`) |
+| `--wxid` | No | User's WeChat ID (auto-detected if omitted) |
+| `--imei` | No | Phone IMEI (fallback key derivation) |
+| `--uin` | No | WeChat UIN (paired with IMEI) |
+| `--exclude-keywords` | No | Group name keywords to exclude |
 
-Standard WeChat backup schema:
-- `wx_chat` — Messages (content field typically encrypted)
-- `wx_friend` — Contact list (nickname/remark may or may not be encrypted)
-- `wx_group` — Group chats
-- `wx_group_member` — Group members
-- `wx_backup_history` — Backup records (display field may be plaintext!)
-- `wx_config` — Configuration
-- `wx_stat` / `wx_session_stat` — Statistics
+### 3. Validate results
 
----
+After decryption, check `decrypt_stats.json` for:
+- Valid decryption rate (should be near 100%)
+- Message counts
+- Excluded sessions
 
-## Step 2: Encryption Method Identification
+If rate < 90%, suggest user provide IMEI/UIN for alternative key derivation.
 
-### 2.1 Check if content is encrypted
+### 4. Present findings
 
-```python
-# Sample content from wx_chat
-cursor.execute("SELECT content FROM wx_chat WHERE msg_type=1 LIMIT 5")
-for row in cursor.fetchall():
-    content = row[0]
-    # If content is hex-encoded bytes, it's likely encrypted
-    # If content is readable text, it's plaintext
-```
+Show user:
+- Total messages decrypted
+- Friend/group counts
+- Output file list
+- Any warnings (low validation rate, excluded groups)
 
-**Signs of encrypted content**:
-- Content is hex-encoded (only 0-9a-fA-F characters)
-- Content length is even (each byte = 2 hex chars)
-- Decoded bytes don't form valid UTF-8
+## Key Technical Notes
 
-### 2.2 Check which fields are encrypted
+### Encryption in NAS WeChat backups
 
-Test each text field:
-- `wx_chat.content` — Usually encrypted
-- `wx_friend.nickname` — MAY be plaintext (check first!)
-- `wx_friend.remark` — MAY be plaintext
-- `wx_group.nickName` — MAY be plaintext
-- `wx_backup_history.display` — Often plaintext (key insight!)
+- `wx_chat.content`: **XOR-encrypted** (hex-encoded ciphertext)
+- `wx_friend.nickname`, `wx_group.nickName`: **May be plaintext** — script auto-detects
+- `wx_backup_history.display`: **Usually plaintext** — used for known-plaintext attack
 
-**Critical**: Don't assume all fields use the same encryption. Some fields may be XOR-encrypted while others remain plaintext — always check before attempting decryption.
+### Key discovery (handled automatically by decrypt.py)
 
----
+1. **Known-plaintext attack** (primary): Match `wx_backup_history.display` (plaintext) to `wx_chat.content` (ciphertext) at same timestamp/session → derive XOR key
+2. **IMEI derivation** (fallback): `MD5(IMEI + UIN)[:7]`
+3. **Brute-force** (last resort): Try all 256 single-byte XOR keys
 
-## Step 3: Known-Plaintext Attack (Primary Decryption Method)
+### Field encryption auto-detection
 
-### 3.1 Why this works
+The script detects if a field is encrypted by checking: hex-only characters + even length + length ≥ 4. If all conditions met, attempts decryption; otherwise treats as plaintext.
 
-The `wx_backup_history.display` field often contains the LAST message text of each session in PLAINTEXT. By matching these with the encrypted `wx_chat.content` at the same timestamp and session, we can recover the encryption key.
+## Output Files
 
-### 3.2 Match plaintext to ciphertext
-
-```python
-# Get known plaintext from backup_history
-cursor.execute("""
-    SELECT display, talkerId, endTime
-    FROM wx_backup_history
-    WHERE display IS NOT NULL AND display != ''
-    AND length(display) > 2 AND length(display) < 30
-""")
-
-for display, talker, endtime in cursor.fetchall():
-    # Find matching encrypted message
-    cursor.execute("""
-        SELECT content FROM wx_chat
-        WHERE session=? AND create_time=? AND msg_type=1
-    """, (talker, endtime))
-    result = cursor.fetchone()
-    if result and result[0]:
-        # We have a plaintext-ciphertext pair!
-        plaintext = display.encode('utf-8')
-        ciphertext = bytes.fromhex(result[0])
-```
-
-### 3.3 Derive the XOR key
-
-```python
-if len(plaintext) == len(ciphertext):
-    for i, (p, c) in enumerate(zip(plaintext, ciphertext)):
-        key_byte = p ^ c
-        print(f"pos {i}: xor_key = 0x{key_byte:02x}")
-```
-
-If the XOR key is constant (all bytes are the same), then it's a simple single-byte XOR cipher. Verify with multiple pairs.
-
-### 3.4 If key is NOT constant
-
-If the key varies per byte, try:
-- **Repeating key XOR**: Check if key repeats with period N
-- **IMEI-based key derivation**: `key = MD5(IMEI + UIN)[:7]` (traditional WeChat method)
-- **Multi-byte key**: Try `key = MD5(IMEI)[:N]` for various N
-
----
-
-## Step 4: Bulk Decryption
-
-### 4.1 Decrypt messages
-
-```python
-XOR_KEY = discovered_key  # Auto-discovered via known-plaintext attack
-
-def decrypt_content(content_hex):
-    if not content_hex or len(content_hex) % 2 != 0:
-        return None
-    try:
-        cipher_bytes = bytes.fromhex(content_hex)
-        plain_bytes = bytes(b ^ XOR_KEY for b in cipher_bytes)
-        return plain_bytes.decode('utf-8', errors='replace')
-    except:
-        return None
-```
-
-### 4.2 Validate decryption quality
-
-```python
-# Sample 5000 messages and check for replacement characters
-valid = 0
-replacement_chars = 0
-total = 0
-
-for row in cursor.execute("SELECT content FROM wx_chat WHERE msg_type=1 ORDER BY RANDOM() LIMIT 5000"):
-    text = decrypt_content(row[0])
-    if text is not None:
-        valid += 1
-        if '\ufffd' in text:  # Unicode replacement character
-            replacement_chars += 1
-    total += 1
-
-print(f"Valid: {valid}/{total}, With replacement chars: {replacement_chars}")
-# Target: 100% valid, 0% replacement chars
-```
-
-### 4.3 Decrypt ALL data
-
-```python
-# User messages (where speak = user's wxid)
-cursor.execute("""
-    SELECT id, session, speak, content, create_time, msg_type
-    FROM wx_chat
-    WHERE speak=?
-""", (user_wxid,))
-
-# All messages
-cursor.execute("""
-    SELECT id, session, speak, content, create_time, msg_type
-    FROM wx_chat
-    WHERE msg_type=1
-""")
-```
-
----
-
-## Step 5: Export & Filtering
-
-### 5.1 Identify and filter unwanted sessions
-
-Common groups to filter out:
-- Gaming/service groups: user provides keywords to match
-- Spam/notification accounts: `@openim` service accounts
-
-```python
-exclude_sessions = set()
-for gid, info in groups.items():
-    name = info.get('name', '')
-    if any(k in name for k in user_provided_keywords):
-        exclude_sessions.add(gid)
-```
-
-### 5.2 Export formats
-
-| Format | File | Content |
-|--------|------|---------|
-| JSON | `user_messages_filtered.json` | User's text messages (excl. filtered groups) |
-| JSON | `all_text_messages_filtered.json` | All text messages (both sides, excl. filtered) |
-| JSON | `friends.json` | Friend list with decrypted/plaintext names |
-| JSON | `groups.json` | Group list with decrypted/plaintext names |
-| TXT | `user_messages.txt` | Plain text: `[timestamp] message` per line |
-
----
-
-## Step 6: Persona Building Support
-
-The exported data can feed directly into the `create-yourself` skill. Key data points:
-
-### For Self Memory
-- Personal timeline (from message timestamps and content)
-- Friend network (from session counts and friend list)
-- Life events (from keyword extraction: school, exam, travel, relationships)
-- Values and habits (from message pattern analysis)
-
-### For Persona
-- Speech patterns (message length distribution, catchphrases)
-- Emoji/emoji usage frequency
-- Emotional valence (positive vs negative word counts)
-- Communication style per relationship type (family, close friends, classmates, teachers)
-- Active hours and weekly patterns
-
----
+| File | Content |
+|------|---------|
+| `user_messages.json` | User's text messages (filtered) |
+| `user_messages.txt` | Plain text: `[timestamp] message` |
+| `all_user_messages.json` | User's all-type messages (filtered) |
+| `all_text_messages.json` | Everyone's text messages (filtered) |
+| `friends.json` | Friend list |
+| `groups.json` | Group list |
+| `decrypt_stats.json` | Statistics & metadata |
 
 ## Troubleshooting
 
-### "Content appears garbled after decryption"
-- Check if the field is actually encrypted (nicknames may be plaintext!)
-- Try different XOR keys
-- Check for multi-byte XOR keys
+| Problem | Solution |
+|---------|----------|
+| Garbled output | Field may be plaintext, not encrypted. Script auto-detects. |
+| No plaintext-ciphertext pairs | `backup_history.display` may be empty. Provide `--imei` + `--uin`. |
+| Low validation rate | Wrong key. Try different IMEI/UIN combinations. |
+| pywxdump won't install | Linux doesn't support pywxdump (requires pywin32). Use this tool instead. |
 
-### "Can't find matching plaintext-ciphertext pairs"
-- The `backup_history.display` field might be empty
-- Try matching by session + approximate timestamp (within ±5 seconds)
-- Some databases use IMEI+UIN based key derivation instead of simple XOR
+## Persona Building
 
-### "Only some messages decrypt correctly"
-- Different message types may use different encryption
-- System messages (type 10000, 10002) may not be encrypted the same way
-- Image/video messages (type 3, 43) have XML content, not simple text
-
-### "pywxdump won't install on Linux"
-- pywxdump has a hard dependency on pywin32 (Windows-only)
-- Use the known-plaintext approach instead
-- The XOR method is simpler and doesn't need pywxdump
-
----
-
-## Encryption Methods Found
-
-| Source | Encryption | Key Derivation | Content Field |
-|--------|-----------|---------------|---------------|
-| NAS WeChat Backup (.xb) | Single-byte XOR | Auto-discovered via known-plaintext | `wx_chat.content` |
-| Android EnMicroMsg.db | SQLCipher | IMEI + UIN → MD5[:7] | Various |
-| iTunes Backup | AES | Device key | Various |
-
-This skill primarily targets the NAS backup format.
+Exported data feeds directly into `create-yourself` skill:
+- Message patterns → speech style, catchphrases, emoji usage
+- Timestamps → active hours, daily rhythms
+- Session analysis → relationship mapping, communication style per group
+- Content themes → values, interests, life events

--- a/.claude/skills/wx-backup-decrypt/SKILL.md
+++ b/.claude/skills/wx-backup-decrypt/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: wx-backup-decrypt
+description: "Decrypt and extract WeChat backup database (.xb files) from NAS/Android backups. Handles XOR-encrypted content fields, friend/group metadata, and exports all messages. | 解密和提取微信备份数据库（.xb文件），处理加密内容字段，导出全部消息。"
+argument-hint: "[database-path] [--imei IMEI] [--output OUTPUT_DIR]"
+version: "1.0.0"
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash
+---
+
+> **Language / 语言**: This skill supports both English and Chinese. Detect the user's language from their first message and respond in the same language throughout.
+
+# WeChat Backup Database Decryptor
+
+## Overview
+
+WeChat backup databases (`.xb` files) on NAS devices or Android backup tools contain encrypted message content. This skill provides a complete pipeline to:
+
+1. **Identify** the database structure and encryption method
+2. **Decrypt** all message content using known-plaintext attack
+3. **Export** messages, friends, and groups in multiple formats
+4. **Filter** out unwanted sessions (e.g., gaming service groups)
+
+## Trigger Conditions
+
+Activate when the user says any of the following:
+- `/wx-backup-decrypt`
+- "解密微信备份数据"
+- "decrypt wechat backup"
+- "微信聊天记录解密"
+- Points to a `.xb` file or directory containing WeChat backup data
+
+---
+
+## Step 1: Database Discovery & Schema Analysis
+
+### 1.1 Locate the database
+
+Search for `.xb` files in the user-provided path:
+
+```bash
+find {path} -name "*.xb" -type f 2>/dev/null
+```
+
+### 1.2 Analyze schema
+
+```python
+import sqlite3
+
+conn = sqlite3.connect(db_path)
+cursor = conn.cursor()
+
+# List tables
+cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+tables = cursor.fetchall()
+
+# Get table schemas
+for table in tables:
+    cursor.execute(f"PRAGMA table_info([{table[0]}])")
+    columns = cursor.fetchall()
+    # Print column info
+
+# Count rows per table
+for table in tables:
+    cursor.execute(f"SELECT COUNT(*) FROM [{table[0]}]")
+    count = cursor.fetchone()[0]
+```
+
+### 1.3 Identify key tables
+
+Standard WeChat backup schema:
+- `wx_chat` — Messages (content field typically encrypted)
+- `wx_friend` — Contact list (nickname/remark may or may not be encrypted)
+- `wx_group` — Group chats
+- `wx_group_member` — Group members
+- `wx_backup_history` — Backup records (display field may be plaintext!)
+- `wx_config` — Configuration
+- `wx_stat` / `wx_session_stat` — Statistics
+
+---
+
+## Step 2: Encryption Method Identification
+
+### 2.1 Check if content is encrypted
+
+```python
+# Sample content from wx_chat
+cursor.execute("SELECT content FROM wx_chat WHERE msg_type=1 LIMIT 5")
+for row in cursor.fetchall():
+    content = row[0]
+    # If content is hex-encoded bytes, it's likely encrypted
+    # If content is readable text, it's plaintext
+```
+
+**Signs of encrypted content**:
+- Content is hex-encoded (only 0-9a-fA-F characters)
+- Content length is even (each byte = 2 hex chars)
+- Decoded bytes don't form valid UTF-8
+
+### 2.2 Check which fields are encrypted
+
+Test each text field:
+- `wx_chat.content` — Usually encrypted
+- `wx_friend.nickname` — MAY be plaintext (check first!)
+- `wx_friend.remark` — MAY be plaintext
+- `wx_group.nickName` — MAY be plaintext
+- `wx_backup_history.display` — Often plaintext (key insight!)
+
+**Critical**: Don't assume all fields use the same encryption. In the discovered case:
+- `wx_chat.content` = XOR 0x36 encrypted
+- `wx_friend.nickname` = Plaintext (NOT encrypted)
+- `wx_group.nickName` = Plaintext (NOT encrypted)
+- `wx_backup_history.display` = Plaintext (gateway to known-plaintext attack)
+
+---
+
+## Step 3: Known-Plaintext Attack (Primary Decryption Method)
+
+### 3.1 Why this works
+
+The `wx_backup_history.display` field often contains the LAST message text of each session in PLAINTEXT. By matching these with the encrypted `wx_chat.content` at the same timestamp and session, we can recover the encryption key.
+
+### 3.2 Match plaintext to ciphertext
+
+```python
+# Get known plaintext from backup_history
+cursor.execute("""
+    SELECT display, talkerId, endTime
+    FROM wx_backup_history
+    WHERE display IS NOT NULL AND display != ''
+    AND length(display) > 2 AND length(display) < 30
+""")
+
+for display, talker, endtime in cursor.fetchall():
+    # Find matching encrypted message
+    cursor.execute("""
+        SELECT content FROM wx_chat
+        WHERE session=? AND create_time=? AND msg_type=1
+    """, (talker, endtime))
+    result = cursor.fetchone()
+    if result and result[0]:
+        # We have a plaintext-ciphertext pair!
+        plaintext = display.encode('utf-8')
+        ciphertext = bytes.fromhex(result[0])
+```
+
+### 3.3 Derive the XOR key
+
+```python
+if len(plaintext) == len(ciphertext):
+    for i, (p, c) in enumerate(zip(plaintext, ciphertext)):
+        key_byte = p ^ c
+        print(f"pos {i}: xor_key = 0x{key_byte:02x}")
+```
+
+If the XOR key is constant (all bytes are the same, e.g., 0x36), then it's a simple single-byte XOR cipher. Verify with multiple pairs.
+
+### 3.4 If key is NOT constant
+
+If the key varies per byte, try:
+- **Repeating key XOR**: Check if key repeats with period N
+- **IMEI-based key derivation**: `key = MD5(IMEI + UIN)[:7]` (traditional WeChat method)
+- **Multi-byte key**: Try `key = MD5(IMEI)[:N]` for various N
+
+---
+
+## Step 4: Bulk Decryption
+
+### 4.1 Decrypt messages
+
+```python
+XOR_KEY = 0x36  # Replace with discovered key
+
+def decrypt_content(content_hex):
+    if not content_hex or len(content_hex) % 2 != 0:
+        return None
+    try:
+        cipher_bytes = bytes.fromhex(content_hex)
+        plain_bytes = bytes(b ^ XOR_KEY for b in cipher_bytes)
+        return plain_bytes.decode('utf-8', errors='replace')
+    except:
+        return None
+```
+
+### 4.2 Validate decryption quality
+
+```python
+# Sample 5000 messages and check for replacement characters
+valid = 0
+replacement_chars = 0
+total = 0
+
+for row in cursor.execute("SELECT content FROM wx_chat WHERE msg_type=1 ORDER BY RANDOM() LIMIT 5000"):
+    text = decrypt_content(row[0])
+    if text is not None:
+        valid += 1
+        if '\ufffd' in text:  # Unicode replacement character
+            replacement_chars += 1
+    total += 1
+
+print(f"Valid: {valid}/{total}, With replacement chars: {replacement_chars}")
+# Target: 100% valid, 0% replacement chars
+```
+
+### 4.3 Decrypt ALL data
+
+```python
+# User messages (where speak = user's wxid)
+cursor.execute("""
+    SELECT id, session, speak, content, create_time, msg_type
+    FROM wx_chat
+    WHERE speak=?
+""", (user_wxid,))
+
+# All messages
+cursor.execute("""
+    SELECT id, session, speak, content, create_time, msg_type
+    FROM wx_chat
+    WHERE msg_type=1
+""")
+```
+
+---
+
+## Step 5: Export & Filtering
+
+### 5.1 Identify and filter unwanted sessions
+
+Common groups to filter out:
+- Gaming service groups (陪玩群): contain keywords like "陪玩", "银雨楼", "点单", "爽文电竞"
+- Spam/notification accounts: `@openim` service accounts
+
+```python
+exclude_sessions = set()
+for gid, info in groups.items():
+    name = info.get('name', '')
+    if any(k in name for k in ['陪玩', '银雨楼', '点单服务号']):
+        exclude_sessions.add(gid)
+```
+
+### 5.2 Export formats
+
+| Format | File | Content |
+|--------|------|---------|
+| JSON | `user_messages_filtered.json` | User's text messages (excl. filtered groups) |
+| JSON | `all_text_messages_filtered.json` | All text messages (both sides, excl. filtered) |
+| JSON | `friends.json` | Friend list with decrypted/plaintext names |
+| JSON | `groups.json` | Group list with decrypted/plaintext names |
+| TXT | `user_messages.txt` | Plain text: `[timestamp] message` per line |
+
+---
+
+## Step 6: Persona Building Support
+
+The exported data can feed directly into the `create-yourself` skill. Key data points:
+
+### For Self Memory
+- Personal timeline (from message timestamps and content)
+- Friend network (from session counts and friend list)
+- Life events (from keyword extraction: school, exam, travel, relationships)
+- Values and habits (from message pattern analysis)
+
+### For Persona
+- Speech patterns (message length distribution, catchphrases)
+- Emoji/emoji usage frequency
+- Emotional valence (positive vs negative word counts)
+- Communication style per relationship type (family, close friends, classmates, teachers)
+- Active hours and weekly patterns
+
+---
+
+## Troubleshooting
+
+### "Content appears garbled after decryption"
+- Check if the field is actually encrypted (nicknames may be plaintext!)
+- Try different XOR keys
+- Check for multi-byte XOR keys
+
+### "Can't find matching plaintext-ciphertext pairs"
+- The `backup_history.display` field might be empty
+- Try matching by session + approximate timestamp (within ±5 seconds)
+- Some databases use IMEI+UIN based key derivation instead of simple XOR
+
+### "Only some messages decrypt correctly"
+- Different message types may use different encryption
+- System messages (type 10000, 10002) may not be encrypted the same way
+- Image/video messages (type 3, 43) have XML content, not simple text
+
+### "pywxdump won't install on Linux"
+- pywxdump has a hard dependency on pywin32 (Windows-only)
+- Use the known-plaintext approach instead
+- The XOR method is simpler and doesn't need pywxdump
+
+---
+
+## Encryption Methods Found
+
+| Source | Encryption | Key Derivation | Content Field |
+|--------|-----------|---------------|---------------|
+| NAS WeChat Backup (.xb) | Single-byte XOR | Constant key (0x36) | `wx_chat.content` |
+| Android EnMicroMsg.db | SQLCipher | IMEI + UIN → MD5[:7] | Various |
+| iTunes Backup | AES | Device key | Various |
+
+This skill primarily targets the NAS backup format.

--- a/.claude/skills/wx-backup-decrypt/SKILL.md
+++ b/.claude/skills/wx-backup-decrypt/SKILL.md
@@ -105,11 +105,7 @@ Test each text field:
 - `wx_group.nickName` — MAY be plaintext
 - `wx_backup_history.display` — Often plaintext (key insight!)
 
-**Critical**: Don't assume all fields use the same encryption. In the discovered case:
-- `wx_chat.content` = XOR 0x36 encrypted
-- `wx_friend.nickname` = Plaintext (NOT encrypted)
-- `wx_group.nickName` = Plaintext (NOT encrypted)
-- `wx_backup_history.display` = Plaintext (gateway to known-plaintext attack)
+**Critical**: Don't assume all fields use the same encryption. Some fields may be XOR-encrypted while others remain plaintext — always check before attempting decryption.
 
 ---
 
@@ -152,7 +148,7 @@ if len(plaintext) == len(ciphertext):
         print(f"pos {i}: xor_key = 0x{key_byte:02x}")
 ```
 
-If the XOR key is constant (all bytes are the same, e.g., 0x36), then it's a simple single-byte XOR cipher. Verify with multiple pairs.
+If the XOR key is constant (all bytes are the same), then it's a simple single-byte XOR cipher. Verify with multiple pairs.
 
 ### 3.4 If key is NOT constant
 
@@ -168,7 +164,7 @@ If the key varies per byte, try:
 ### 4.1 Decrypt messages
 
 ```python
-XOR_KEY = 0x36  # Replace with discovered key
+XOR_KEY = 0x00  # Replace with discovered key
 
 def decrypt_content(content_hex):
     if not content_hex or len(content_hex) % 2 != 0:
@@ -226,14 +222,14 @@ cursor.execute("""
 ### 5.1 Identify and filter unwanted sessions
 
 Common groups to filter out:
-- Gaming service groups (陪玩群): contain keywords like "陪玩", "银雨楼", "点单", "爽文电竞"
+- Gaming/service groups: user provides keywords to match
 - Spam/notification accounts: `@openim` service accounts
 
 ```python
 exclude_sessions = set()
 for gid, info in groups.items():
     name = info.get('name', '')
-    if any(k in name for k in ['陪玩', '银雨楼', '点单服务号']):
+    if any(k in name for k in user_provided_keywords):
         exclude_sessions.add(gid)
 ```
 
@@ -296,7 +292,7 @@ The exported data can feed directly into the `create-yourself` skill. Key data p
 
 | Source | Encryption | Key Derivation | Content Field |
 |--------|-----------|---------------|---------------|
-| NAS WeChat Backup (.xb) | Single-byte XOR | Constant key (0x36) | `wx_chat.content` |
+| NAS WeChat Backup (.xb) | Single-byte XOR | Auto-discovered via known-plaintext | `wx_chat.content` |
 | Android EnMicroMsg.db | SQLCipher | IMEI + UIN → MD5[:7] | Various |
 | iTunes Backup | AES | Device key | Various |
 

--- a/.claude/skills/wx-backup-decrypt/tools/decrypt.py
+++ b/.claude/skills/wx-backup-decrypt/tools/decrypt.py
@@ -131,7 +131,7 @@ def imei_key_derivation(imei, uin=None):
     """Try IMEI-based key derivation (traditional WeChat method)."""
     key_str = imei + str(uin) if uin else imei
     md5_hash = hashlib.md5(key_str.encode()).hexdigest()
-    return bytes.fromhex(md5_hash[:7])
+    return bytes.fromhex(md5_hash[:8])
 
 
 def validate_key(db_path, key_bytes):

--- a/.claude/skills/wx-backup-decrypt/tools/decrypt.py
+++ b/.claude/skills/wx-backup-decrypt/tools/decrypt.py
@@ -20,6 +20,9 @@ import argparse
 from collections import Counter
 from datetime import datetime
 
+# Global for exclude keywords (set by decrypt_all)
+exclude_keywords_global = []
+
 
 def decrypt_xor(content_hex, key_bytes):
     """Decrypt hex-encoded content using XOR with key bytes."""
@@ -150,10 +153,15 @@ def validate_key(db_path, key_bytes):
     return valid / total, replacement
 
 
-def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions=None):
+def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions=None, exclude_keywords=None):
     """Decrypt entire database and export to JSON files."""
     if exclude_sessions is None:
         exclude_sessions = set()
+    if exclude_keywords is None:
+        exclude_keywords = []
+
+    global exclude_keywords_global
+    exclude_keywords_global = exclude_keywords
 
     os.makedirs(output_dir, exist_ok=True)
     conn = sqlite3.connect(db_path)
@@ -207,10 +215,11 @@ def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions
 
         groups[gid] = {'name': name_dec or '', 'remark': remark or '', 'members': mc}
 
-    # Identify exclude sessions
+    # Identify exclude sessions based on user-provided keywords
+    # Keywords are passed via --exclude-keywords argument
     for gid, info in groups.items():
         name = info.get('name', '')
-        if any(k in name for k in ['陪玩', '银雨楼', '点单服务号', '爽文电竞']):
+        if any(k in name for k in exclude_keywords_global):
             exclude_sessions.add(gid)
 
     # Decrypt user messages
@@ -296,8 +305,8 @@ def main():
     parser.add_argument('--uin', default=None, help='WeChat UIN')
     parser.add_argument('--output', default='./wx_decrypted', help='Output directory')
     parser.add_argument('--exclude-keywords', nargs='+',
-                        default=['陪玩', '银雨楼', '点单服务号'],
-                        help='Keywords for sessions to exclude')
+                        default=[],
+                        help='Keywords for group session names to exclude (e.g. --exclude-keywords foo bar)')
     args = parser.parse_args()
 
     print(f"Analyzing database: {args.db}")
@@ -354,7 +363,7 @@ def main():
 
     # Decrypt all
     print(f"\nDecrypting database with key 0x{key_bytes[0]:02x}...")
-    stats = decrypt_all(args.db, key_bytes, args.output, exclude_sessions=set())
+    stats = decrypt_all(args.db, key_bytes, args.output, exclude_sessions=set(), exclude_keywords=args.exclude_keywords)
 
     print(f"\n=== Decryption Complete ===")
     for k, v in stats.items():

--- a/.claude/skills/wx-backup-decrypt/tools/decrypt.py
+++ b/.claude/skills/wx-backup-decrypt/tools/decrypt.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+WeChat Backup Database Decryptor
+Decrypts .xb SQLite databases from NAS/Android WeChat backups.
+
+Usage:
+    python decrypt.py --db PATH [--imei IMEI] [--output DIR] [--exclude-keywords KEYWORDS]
+
+Key discovery method:
+    1. Try known-plaintext attack (using wx_backup_history.display as plaintext)
+    2. If IMEI provided, try MD5(IMEI)[:7] as key
+    3. Fallback: brute-force single-byte XOR (256 possibilities)
+"""
+
+import sqlite3
+import hashlib
+import json
+import os
+import argparse
+from collections import Counter
+from datetime import datetime
+
+
+def decrypt_xor(content_hex, key_bytes):
+    """Decrypt hex-encoded content using XOR with key bytes."""
+    if not content_hex or len(content_hex) % 2 != 0:
+        return None
+    try:
+        cipher = bytes.fromhex(content_hex)
+        if len(key_bytes) == 1:
+            plain = bytes(b ^ key_bytes[0] for b in cipher)
+        else:
+            plain = bytes(b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(cipher))
+        return plain.decode('utf-8', errors='replace')
+    except Exception:
+        return None
+
+
+def known_plaintext_attack(db_path):
+    """Discover encryption key by matching plaintext from wx_backup_history."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Get plaintext-ciphertext pairs from backup_history
+    cursor.execute("""
+        SELECT display, talkerId, endTime
+        FROM wx_backup_history
+        WHERE display IS NOT NULL AND display != ''
+        AND length(display) > 2 AND length(display) < 50
+    """)
+
+    pairs = []
+    for display, talker, endtime in cursor.fetchall():
+        cursor.execute("""
+            SELECT content FROM wx_chat
+            WHERE session=? AND create_time=? AND msg_type=1
+        """, (talker, endtime))
+        result = cursor.fetchone()
+        if result and result[0]:
+            plain_bytes = display.encode('utf-8')
+            hex_content = result[0]
+            if len(hex_content) % 2 == 0:
+                try:
+                    cipher_bytes = bytes.fromhex(hex_content)
+                    if len(plain_bytes) == len(cipher_bytes):
+                        pairs.append((plain_bytes, cipher_bytes))
+                except ValueError:
+                    continue
+
+    conn.close()
+
+    if not pairs:
+        return None
+
+    # Extract XOR key bytes from all pairs
+    key_bytes_list = []
+    for plain, cipher in pairs:
+        keys = [p ^ c for p, c in zip(plain, cipher)]
+        key_bytes_list.append(keys)
+
+    # Check if all pairs yield the same constant key
+    first_key = key_bytes_list[0][0] if key_bytes_list else None
+    is_constant = all(
+        k == first_key
+        for keys in key_bytes_list
+        for k in keys
+    )
+
+    if is_constant and first_key is not None:
+        return bytes([first_key]), 'constant_xor'
+
+    # Check for repeating key
+    if key_bytes_list:
+        max_len = max(len(k) for k in key_bytes_list)
+        # Try to find repeating period
+        for period in range(1, max_len + 1):
+            is_repeating = True
+            for keys in key_bytes_list:
+                if len(keys) < period:
+                    continue
+                for i in range(period, len(keys)):
+                    if keys[i] != keys[i % period]:
+                        is_repeating = False
+                        break
+            if is_repeating:
+                key = bytes(key_bytes_list[0][:period])
+                return key, 'repeating_xor'
+
+    return None
+
+
+def imei_key_derivation(imei, uin=None):
+    """Try IMEI-based key derivation (traditional WeChat method)."""
+    if uin:
+        key_str = imei + str(uin)
+    else:
+        key_str = imei
+    md5_hash = hashlib.md5(key_str.encode()).hexdigest()
+    return bytes.fromhex(md5_hash[:7])
+
+
+def validate_key(db_path, key_bytes):
+    """Validate a key by checking decryption quality on a sample."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        SELECT content FROM wx_chat
+        WHERE msg_type=1 AND content IS NOT NULL AND content != ''
+        ORDER BY RANDOM() LIMIT 1000
+    """)
+
+    valid = 0
+    total = 0
+    replacement = 0
+
+    for row in cursor.fetchall():
+        text = decrypt_xor(row[0], key_bytes)
+        if text is not None:
+            total += 1
+            valid += 1
+            if '\ufffd' in text:
+                replacement += 1
+
+    conn.close()
+
+    if total == 0:
+        return 0.0, 0
+
+    return valid / total, replacement
+
+
+def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions=None):
+    """Decrypt entire database and export to JSON files."""
+    if exclude_sessions is None:
+        exclude_sessions = set()
+
+    os.makedirs(output_dir, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Discover user wxid if not provided
+    if not user_wxid:
+        cursor.execute("""
+            SELECT speak, COUNT(*) as cnt
+            FROM wx_chat
+            WHERE msg_type=1
+            GROUP BY speak
+            ORDER BY cnt DESC
+            LIMIT 1
+        """)
+        result = cursor.fetchone()
+        user_wxid = result[0] if result else None
+
+    print(f"User wxid: {user_wxid}")
+
+    # Decrypt friends
+    cursor.execute("SELECT friend_id, nickname, remark, sex FROM wx_friend")
+    friends = {}
+    for f in cursor.fetchall():
+        fid, nick, remark, sex = f
+        # Try decrypting nickname - if it's already valid UTF-8 plaintext, keep it
+        nick_dec = nick
+        if nick and all(c in '0123456789abcdefABCDEF' for c in nick) and len(nick) % 2 == 0 and len(nick) >= 4:
+            dec = decrypt_xor(nick, key_bytes)
+            if dec and '\ufffd' not in dec:
+                nick_dec = dec
+
+        remark_dec = remark
+        if remark and all(c in '0123456789abcdefABCDEF' for c in remark) and len(remark) % 2 == 0 and len(remark) >= 4:
+            dec = decrypt_xor(remark, key_bytes)
+            if dec and '\ufffd' not in dec:
+                remark_dec = dec
+
+        friends[fid] = {'nick': nick_dec or '', 'remark': remark_dec or '', 'sex': sex}
+
+    # Decrypt groups
+    cursor.execute("SELECT groupid, nickName, remark, memberCount FROM wx_group")
+    groups = {}
+    for g in cursor.fetchall():
+        gid, name, remark, mc = g
+        name_dec = name
+        if name and all(c in '0123456789abcdefABCDEF' for c in name) and len(name) % 2 == 0 and len(name) >= 4:
+            dec = decrypt_xor(name, key_bytes)
+            if dec and '\ufffd' not in dec:
+                name_dec = dec
+
+        groups[gid] = {'name': name_dec or '', 'remark': remark or '', 'members': mc}
+
+    # Identify exclude sessions
+    for gid, info in groups.items():
+        name = info.get('name', '')
+        if any(k in name for k in ['陪玩', '银雨楼', '点单服务号', '爽文电竞']):
+            exclude_sessions.add(gid)
+
+    # Decrypt user messages
+    cursor.execute("""
+        SELECT id, session, speak, content, create_time, msg_type
+        FROM wx_chat WHERE speak=?
+    """, (user_wxid,))
+    user_msgs = []
+    for r in cursor.fetchall():
+        text = decrypt_xor(r[3], key_bytes) if r[3] else None
+        ts = datetime.fromtimestamp(r[4] / 1000) if r[4] else None
+        if r[1] not in exclude_sessions:
+            user_msgs.append({
+                'id': r[0], 'session': r[1], 'speak': r[2],
+                'text': text, 'time': r[4],
+                'time_str': ts.strftime('%Y-%m-%d %H:%M:%S') if ts else None,
+                'msg_type': r[5]
+            })
+
+    # Decrypt all text messages
+    cursor.execute("SELECT id, session, speak, content, create_time FROM wx_chat WHERE msg_type=1")
+    all_msgs = []
+    for r in cursor.fetchall():
+        text = decrypt_xor(r[3], key_bytes) if r[3] else None
+        ts = datetime.fromtimestamp(r[4] / 1000) if r[4] else None
+        if r[1] not in exclude_sessions:
+            all_msgs.append({
+                'id': r[0], 'session': r[1], 'speak': r[2],
+                'text': text, 'time': r[4],
+                'time_str': ts.strftime('%Y-%m-%d %H:%M:%S') if ts else None
+            })
+
+    conn.close()
+
+    # Save exports
+    with open(os.path.join(output_dir, 'friends.json'), 'w', encoding='utf-8') as f:
+        json.dump(friends, f, ensure_ascii=False, indent=2)
+
+    with open(os.path.join(output_dir, 'groups.json'), 'w', encoding='utf-8') as f:
+        json.dump(groups, f, ensure_ascii=False, indent=2)
+
+    user_text = [m for m in user_msgs if m['msg_type'] == 1]
+    with open(os.path.join(output_dir, 'user_messages.json'), 'w', encoding='utf-8') as f:
+        json.dump(user_text, f, ensure_ascii=False, indent=2)
+
+    with open(os.path.join(output_dir, 'all_user_messages.json'), 'w', encoding='utf-8') as f:
+        json.dump(user_msgs, f, ensure_ascii=False, indent=2)
+
+    with open(os.path.join(output_dir, 'all_text_messages.json'), 'w', encoding='utf-8') as f:
+        json.dump(all_msgs, f, ensure_ascii=False, indent=2)
+
+    # Save plain text
+    with open(os.path.join(output_dir, 'user_messages.txt'), 'w', encoding='utf-8') as f:
+        for m in user_text:
+            f.write(f"[{m['time_str']}] {m['text']}\n")
+
+    # Stats
+    stats = {
+        'user_wxid': user_wxid,
+        'key_method': 'XOR 0x{:02x}'.format(key_bytes[0]) if len(key_bytes) == 1 else key_bytes.hex(),
+        'total_user_messages': len(user_msgs),
+        'user_text_messages': len(user_text),
+        'total_text_messages': len(all_msgs),
+        'friends_count': len(friends),
+        'groups_count': len(groups),
+        'excluded_sessions': list(exclude_sessions),
+        'export_files': [
+            'friends.json', 'groups.json', 'user_messages.json',
+            'all_user_messages.json', 'all_text_messages.json', 'user_messages.txt'
+        ]
+    }
+
+    with open(os.path.join(output_dir, 'decrypt_stats.json'), 'w', encoding='utf-8') as f:
+        json.dump(stats, f, ensure_ascii=False, indent=2)
+
+    return stats
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Decrypt WeChat backup database')
+    parser.add_argument('--db', required=True, help='Path to .xb database file')
+    parser.add_argument('--imei', default=None, help='Phone IMEI number')
+    parser.add_argument('--uin', default=None, help='WeChat UIN')
+    parser.add_argument('--output', default='./wx_decrypted', help='Output directory')
+    parser.add_argument('--exclude-keywords', nargs='+',
+                        default=['陪玩', '银雨楼', '点单服务号'],
+                        help='Keywords for sessions to exclude')
+    args = parser.parse_args()
+
+    print(f"Analyzing database: {args.db}")
+
+    # Step 1: Try known-plaintext attack
+    print("\n[1] Trying known-plaintext attack...")
+    result = known_plaintext_attack(args.db)
+
+    if result:
+        key_bytes, method = result
+        print(f"  Found key via {method}: {key_bytes.hex()} (0x{key_bytes[0]:02x})")
+
+        # Validate
+        rate, replacements = validate_key(args.db, key_bytes)
+        print(f"  Validation: {rate*100:.1f}% valid, {replacements} replacement chars")
+    else:
+        print("  Known-plaintext attack failed.")
+
+        # Step 2: Try IMEI-based key
+        if args.imei:
+            print("\n[2] Trying IMEI-based key derivation...")
+            key_bytes = imei_key_derivation(args.imei, args.uin)
+            print(f"  Derived key: {key_bytes.hex()}")
+
+            rate, replacements = validate_key(args.db, key_bytes)
+            print(f"  Validation: {rate*100:.1f}% valid, {replacements} replacement chars")
+
+            if rate < 0.9:
+                # Step 3: Brute-force single-byte XOR
+                print("\n[3] Brute-forcing single-byte XOR...")
+                best_key = None
+                best_rate = 0
+                for b in range(256):
+                    k = bytes([b])
+                    r, rep = validate_key(args.db, k)
+                    if r > best_rate:
+                        best_rate = r
+                        best_key = k
+                key_bytes = best_key
+                print(f"  Best key: 0x{key_bytes[0]:02x} (rate: {best_rate*100:.1f}%)")
+        else:
+            # Brute-force
+            print("\n[2] Brute-forcing single-byte XOR...")
+            best_key = None
+            best_rate = 0
+            for b in range(256):
+                k = bytes([b])
+                r, rep = validate_key(args.db, k)
+                if r > best_rate:
+                    best_rate = r
+                    best_key = k
+            key_bytes = best_key
+            print(f"  Best key: 0x{key_bytes[0]:02x} (rate: {best_rate*100:.1f}%)")
+
+    # Decrypt all
+    print(f"\nDecrypting database with key 0x{key_bytes[0]:02x}...")
+    stats = decrypt_all(args.db, key_bytes, args.output, exclude_sessions=set())
+
+    print(f"\n=== Decryption Complete ===")
+    for k, v in stats.items():
+        if k != 'excluded_sessions':
+            print(f"  {k}: {v}")
+
+    print(f"\nFiles saved to: {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/wx-backup-decrypt/tools/decrypt.py
+++ b/.claude/skills/wx-backup-decrypt/tools/decrypt.py
@@ -4,11 +4,11 @@ WeChat Backup Database Decryptor
 Decrypts .xb SQLite databases from NAS/Android WeChat backups.
 
 Usage:
-    python decrypt.py --db PATH [--imei IMEI] [--output DIR] [--exclude-keywords KEYWORDS]
+    python decrypt.py --db PATH [--wxid WXID] [--imei IMEI] [--output DIR] [--exclude-keywords KEYWORDS]
 
 Key discovery method:
     1. Try known-plaintext attack (using wx_backup_history.display as plaintext)
-    2. If IMEI provided, try MD5(IMEI)[:7] as key
+    2. If IMEI provided, try MD5(IMEI+UIN)[:7] as key
     3. Fallback: brute-force single-byte XOR (256 possibilities)
 """
 
@@ -20,8 +20,12 @@ import argparse
 from collections import Counter
 from datetime import datetime
 
-# Global for exclude keywords (set by decrypt_all)
-exclude_keywords_global = []
+
+def _is_likely_hex(s):
+    """Check if a string looks like hex-encoded ciphertext."""
+    if not s or len(s) < 4 or len(s) % 2 != 0:
+        return False
+    return all(c in '0123456789abcdefABCDEF' for c in s)
 
 
 def decrypt_xor(content_hex, key_bytes):
@@ -39,12 +43,22 @@ def decrypt_xor(content_hex, key_bytes):
         return None
 
 
+def _try_decrypt_field(value, key_bytes):
+    """Try decrypting a field value. Returns original if likely plaintext."""
+    if not value:
+        return value
+    if _is_likely_hex(value):
+        dec = decrypt_xor(value, key_bytes)
+        if dec and '\ufffd' not in dec:
+            return dec
+    return value
+
+
 def known_plaintext_attack(db_path):
     """Discover encryption key by matching plaintext from wx_backup_history."""
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
 
-    # Get plaintext-ciphertext pairs from backup_history
     cursor.execute("""
         SELECT display, talkerId, endTime
         FROM wx_backup_history
@@ -62,7 +76,7 @@ def known_plaintext_attack(db_path):
         if result and result[0]:
             plain_bytes = display.encode('utf-8')
             hex_content = result[0]
-            if len(hex_content) % 2 == 0:
+            if _is_likely_hex(hex_content):
                 try:
                     cipher_bytes = bytes.fromhex(hex_content)
                     if len(plain_bytes) == len(cipher_bytes):
@@ -81,7 +95,7 @@ def known_plaintext_attack(db_path):
         keys = [p ^ c for p, c in zip(plain, cipher)]
         key_bytes_list.append(keys)
 
-    # Check if all pairs yield the same constant key
+    # Check if all pairs yield the same constant key (single-byte XOR)
     first_key = key_bytes_list[0][0] if key_bytes_list else None
     is_constant = all(
         k == first_key
@@ -95,7 +109,6 @@ def known_plaintext_attack(db_path):
     # Check for repeating key
     if key_bytes_list:
         max_len = max(len(k) for k in key_bytes_list)
-        # Try to find repeating period
         for period in range(1, max_len + 1):
             is_repeating = True
             for keys in key_bytes_list:
@@ -105,6 +118,8 @@ def known_plaintext_attack(db_path):
                     if keys[i] != keys[i % period]:
                         is_repeating = False
                         break
+                if not is_repeating:
+                    break
             if is_repeating:
                 key = bytes(key_bytes_list[0][:period])
                 return key, 'repeating_xor'
@@ -114,10 +129,7 @@ def known_plaintext_attack(db_path):
 
 def imei_key_derivation(imei, uin=None):
     """Try IMEI-based key derivation (traditional WeChat method)."""
-    if uin:
-        key_str = imei + str(uin)
-    else:
-        key_str = imei
+    key_str = imei + str(uin) if uin else imei
     md5_hash = hashlib.md5(key_str.encode()).hexdigest()
     return bytes.fromhex(md5_hash[:7])
 
@@ -153,15 +165,23 @@ def validate_key(db_path, key_bytes):
     return valid / total, replacement
 
 
-def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions=None, exclude_keywords=None):
+def brute_force_key(db_path):
+    """Brute-force single-byte XOR key by maximizing validation rate."""
+    best_key = bytes([0])
+    best_rate = 0.0
+    for b in range(256):
+        k = bytes([b])
+        r, _ = validate_key(db_path, k)
+        if r > best_rate:
+            best_rate = r
+            best_key = k
+    return best_key, best_rate
+
+
+def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_keywords=None):
     """Decrypt entire database and export to JSON files."""
-    if exclude_sessions is None:
-        exclude_sessions = set()
     if exclude_keywords is None:
         exclude_keywords = []
-
-    global exclude_keywords_global
-    exclude_keywords_global = exclude_keywords
 
     os.makedirs(output_dir, exist_ok=True)
     conn = sqlite3.connect(db_path)
@@ -187,39 +207,28 @@ def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions
     friends = {}
     for f in cursor.fetchall():
         fid, nick, remark, sex = f
-        # Try decrypting nickname - if it's already valid UTF-8 plaintext, keep it
-        nick_dec = nick
-        if nick and all(c in '0123456789abcdefABCDEF' for c in nick) and len(nick) % 2 == 0 and len(nick) >= 4:
-            dec = decrypt_xor(nick, key_bytes)
-            if dec and '\ufffd' not in dec:
-                nick_dec = dec
-
-        remark_dec = remark
-        if remark and all(c in '0123456789abcdefABCDEF' for c in remark) and len(remark) % 2 == 0 and len(remark) >= 4:
-            dec = decrypt_xor(remark, key_bytes)
-            if dec and '\ufffd' not in dec:
-                remark_dec = dec
-
-        friends[fid] = {'nick': nick_dec or '', 'remark': remark_dec or '', 'sex': sex}
+        friends[fid] = {
+            'nick': _try_decrypt_field(nick, key_bytes) or '',
+            'remark': _try_decrypt_field(remark, key_bytes) or '',
+            'sex': sex,
+        }
 
     # Decrypt groups
     cursor.execute("SELECT groupid, nickName, remark, memberCount FROM wx_group")
     groups = {}
     for g in cursor.fetchall():
         gid, name, remark, mc = g
-        name_dec = name
-        if name and all(c in '0123456789abcdefABCDEF' for c in name) and len(name) % 2 == 0 and len(name) >= 4:
-            dec = decrypt_xor(name, key_bytes)
-            if dec and '\ufffd' not in dec:
-                name_dec = dec
+        groups[gid] = {
+            'name': _try_decrypt_field(name, key_bytes) or '',
+            'remark': remark or '',
+            'members': mc,
+        }
 
-        groups[gid] = {'name': name_dec or '', 'remark': remark or '', 'members': mc}
-
-    # Identify exclude sessions based on user-provided keywords
-    # Keywords are passed via --exclude-keywords argument
+    # Identify exclude sessions based on keywords
+    exclude_sessions = set()
     for gid, info in groups.items():
         name = info.get('name', '')
-        if any(k in name for k in exclude_keywords_global):
+        if any(k in name for k in exclude_keywords):
             exclude_sessions.add(gid)
 
     # Decrypt user messages
@@ -236,11 +245,14 @@ def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions
                 'id': r[0], 'session': r[1], 'speak': r[2],
                 'text': text, 'time': r[4],
                 'time_str': ts.strftime('%Y-%m-%d %H:%M:%S') if ts else None,
-                'msg_type': r[5]
+                'msg_type': r[5],
             })
 
     # Decrypt all text messages
-    cursor.execute("SELECT id, session, speak, content, create_time FROM wx_chat WHERE msg_type=1")
+    cursor.execute("""
+        SELECT id, session, speak, content, create_time
+        FROM wx_chat WHERE msg_type=1
+    """)
     all_msgs = []
     for r in cursor.fetchall():
         text = decrypt_xor(r[3], key_bytes) if r[3] else None
@@ -249,7 +261,7 @@ def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions
             all_msgs.append({
                 'id': r[0], 'session': r[1], 'speak': r[2],
                 'text': text, 'time': r[4],
-                'time_str': ts.strftime('%Y-%m-%d %H:%M:%S') if ts else None
+                'time_str': ts.strftime('%Y-%m-%d %H:%M:%S') if ts else None,
             })
 
     conn.close()
@@ -271,7 +283,6 @@ def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions
     with open(os.path.join(output_dir, 'all_text_messages.json'), 'w', encoding='utf-8') as f:
         json.dump(all_msgs, f, ensure_ascii=False, indent=2)
 
-    # Save plain text
     with open(os.path.join(output_dir, 'user_messages.txt'), 'w', encoding='utf-8') as f:
         for m in user_text:
             f.write(f"[{m['time_str']}] {m['text']}\n")
@@ -288,8 +299,8 @@ def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions
         'excluded_sessions': list(exclude_sessions),
         'export_files': [
             'friends.json', 'groups.json', 'user_messages.json',
-            'all_user_messages.json', 'all_text_messages.json', 'user_messages.txt'
-        ]
+            'all_user_messages.json', 'all_text_messages.json', 'user_messages.txt',
+        ],
     }
 
     with open(os.path.join(output_dir, 'decrypt_stats.json'), 'w', encoding='utf-8') as f:
@@ -301,69 +312,54 @@ def decrypt_all(db_path, key_bytes, output_dir, user_wxid=None, exclude_sessions
 def main():
     parser = argparse.ArgumentParser(description='Decrypt WeChat backup database')
     parser.add_argument('--db', required=True, help='Path to .xb database file')
+    parser.add_argument('--wxid', default=None, help='User WeChat ID (auto-detected if omitted)')
     parser.add_argument('--imei', default=None, help='Phone IMEI number')
     parser.add_argument('--uin', default=None, help='WeChat UIN')
     parser.add_argument('--output', default='./wx_decrypted', help='Output directory')
-    parser.add_argument('--exclude-keywords', nargs='+',
-                        default=[],
-                        help='Keywords for group session names to exclude (e.g. --exclude-keywords foo bar)')
+    parser.add_argument('--exclude-keywords', nargs='+', default=[],
+                        help='Keywords for group names to exclude')
     args = parser.parse_args()
 
     print(f"Analyzing database: {args.db}")
 
-    # Step 1: Try known-plaintext attack
+    # Step 1: Known-plaintext attack
     print("\n[1] Trying known-plaintext attack...")
     result = known_plaintext_attack(args.db)
 
+    key_bytes = None
     if result:
         key_bytes, method = result
-        print(f"  Found key via {method}: {key_bytes.hex()} (0x{key_bytes[0]:02x})")
-
-        # Validate
+        print(f"  Found key via {method}: {key_bytes.hex()}")
         rate, replacements = validate_key(args.db, key_bytes)
         print(f"  Validation: {rate*100:.1f}% valid, {replacements} replacement chars")
     else:
         print("  Known-plaintext attack failed.")
 
-        # Step 2: Try IMEI-based key
+        # Step 2: IMEI-based key
         if args.imei:
             print("\n[2] Trying IMEI-based key derivation...")
             key_bytes = imei_key_derivation(args.imei, args.uin)
             print(f"  Derived key: {key_bytes.hex()}")
-
             rate, replacements = validate_key(args.db, key_bytes)
             print(f"  Validation: {rate*100:.1f}% valid, {replacements} replacement chars")
 
             if rate < 0.9:
-                # Step 3: Brute-force single-byte XOR
                 print("\n[3] Brute-forcing single-byte XOR...")
-                best_key = None
-                best_rate = 0
-                for b in range(256):
-                    k = bytes([b])
-                    r, rep = validate_key(args.db, k)
-                    if r > best_rate:
-                        best_rate = r
-                        best_key = k
-                key_bytes = best_key
+                key_bytes, best_rate = brute_force_key(args.db)
                 print(f"  Best key: 0x{key_bytes[0]:02x} (rate: {best_rate*100:.1f}%)")
         else:
             # Brute-force
             print("\n[2] Brute-forcing single-byte XOR...")
-            best_key = None
-            best_rate = 0
-            for b in range(256):
-                k = bytes([b])
-                r, rep = validate_key(args.db, k)
-                if r > best_rate:
-                    best_rate = r
-                    best_key = k
-            key_bytes = best_key
+            key_bytes, best_rate = brute_force_key(args.db)
             print(f"  Best key: 0x{key_bytes[0]:02x} (rate: {best_rate*100:.1f}%)")
 
     # Decrypt all
-    print(f"\nDecrypting database with key 0x{key_bytes[0]:02x}...")
-    stats = decrypt_all(args.db, key_bytes, args.output, exclude_sessions=set(), exclude_keywords=args.exclude_keywords)
+    print(f"\nDecrypting database with key {key_bytes.hex()}...")
+    stats = decrypt_all(
+        args.db, key_bytes, args.output,
+        user_wxid=args.wxid,
+        exclude_keywords=args.exclude_keywords,
+    )
 
     print(f"\n=== Decryption Complete ===")
     for k, v in stats.items():

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,11 @@ desktop/package-lock.json
 # Desktop brand asset candidates (keep only selected ones in public/)
 desktop/brand-assets/
 
-# Claude local config & auto-generated
-.claude/
+# Claude local config & auto-generated (keep skills)
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/wx-backup-decrypt/
 
 # Superpowers plans & specs (local only)
 docs/superpowers/


### PR DESCRIPTION
## Summary
- Add WeChat backup database (.xb) decrypt skill — known-plaintext attack to auto-discover XOR key, export messages/friends/groups
- Optimize skill v1.1.0: trim SKILL.md redundancy (330→120 lines), extract `_is_likely_hex()` + `_try_decrypt_field()` helpers, remove global variable, add `--wxid` param
- Fix `imei_key_derivation` crash: `md5_hash[:7]` → `[:8]` (bytes.fromhex needs even-length hex string)

## Test plan
- [x] Python syntax check passes
- [x] `--help` CLI output correct
- [x] Unit tests: XOR round-trip, `_is_likely_hex`, `_try_decrypt_field`, `imei_key_derivation` all pass
- [ ] Integration test with real .xb database file

🤖 Generated with [Claude Code](https://claude.com/claude-code)