### PR TITLE
feat: support effort max for deepseek and opus-4-7 models

### DIFF
--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -55,6 +55,12 @@ export function modelSupportsMaxEffort(model: string): boolean {
   if (supported3P !== undefined) {
     return supported3P
   }
+  if (model.toLowerCase().includes('deepseek')) {
+    return true
+  }
+  if (model.toLowerCase().includes('opus-4-7')) {
+    return true
+  }
   if (model.toLowerCase().includes('opus-4-6')) {
     return true
   }
@@ -95,10 +101,7 @@ export function parseEffortValue(value: unknown): EffortValue | undefined {
 export function toPersistableEffort(
   value: EffortValue | undefined,
 ): EffortLevel | undefined {
-  if (value === 'low' || value === 'medium' || value === 'high') {
-    return value
-  }
-  if (value === 'max' && process.env.USER_TYPE === 'ant') {
+  if (value === 'low' || value === 'medium' || value === 'high' || value === 'max') {
     return value
   }
   return undefined

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -720,11 +720,7 @@ export const SettingsSchema = lazySchema(() =>
             'enabled automatically for supported models.',
         ),
       effortLevel: z
-        .enum(
-          process.env.USER_TYPE === 'ant'
-            ? ['low', 'medium', 'high', 'max']
-            : ['low', 'medium', 'high'],
-        )
+        .enum(['low', 'medium', 'high', 'max'])
         .optional()
         .catch(undefined)
         .describe('Persisted effort level for supported models.'),


### PR DESCRIPTION
## Summary
- Add deepseek and opus-4-7 to the effort max allowlist
- Remove USER_TYPE restriction, allowing all users to use max effort