### PR TITLE
feat: improve line prefix display with box drawing character

### DIFF
--- a/src/tools/FileEditTool/prompt.ts
+++ b/src/tools/FileEditTool/prompt.ts
@@ -11,7 +11,7 @@ export function getEditToolDescription(): string {
 
 function getDefaultEditDescription(): string {
   const prefixFormat = isCompactLinePrefixEnabled()
-    ? 'line number + tab'
+    ? 'line number + │ (box drawing character)'
     : 'spaces + line number + arrow'
   const minimalUniquenessHint =
     process.env.USER_TYPE === 'ant'

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -303,7 +303,7 @@ export function addLineNumbers({
 
   if (isCompactLinePrefixEnabled()) {
     return lines
-      .map((line, index) => `${index + startLine}\t${line}`)
+      .map((line, index) => `${index + startLine}│${line}`)
       .join('\n')
   }
 
@@ -319,11 +319,11 @@ export function addLineNumbers({
 }
 
 /**
- * Inverse of addLineNumbers — strips the `N→` or `N\t` prefix from a single
+ * Inverse of addLineNumbers — strips the `N→`, `N│` or `N\t` prefix from a single
  * line. Co-located so format changes here and in addLineNumbers stay in sync.
  */
 export function stripLineNumberPrefix(line: string): string {
-  const match = line.match(/^\s*\d+[\u2192\t](.*)$/)
+  const match = line.match(/^\s*\d+[\u2192\u2502\t](.*)$/)
   return match?.[1] ?? line
 }
 


### PR DESCRIPTION
## Summary
- Replace tab character with box drawing character `│` for line number prefix
- Update regex pattern to handle new prefix format

## Motivation
DeepSeekV4 often confuses the tab separator in line number prefixes with actual tab characters in file content when updating  code files, leading to update errors. Using `│` as the line number prefix separator eliminates this confusion.