### PR TITLE
Quality: Hardcoded empty GrowthBook key returns

### DIFF
--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -5,7 +5,7 @@ import { isEnvTruthy } from '../utils/envUtils.js'
 export function getGrowthBookClientKey(): string {
   return process.env.USER_TYPE === 'ant'
     ? isEnvTruthy(process.env.ENABLE_GROWTHBOOK_DEV)
-      ? ''
-      : ''
+      ? process.env.GROWTHBOOK_DEV_KEY || ''
+      : process.env.GROWTHBOOK_PROD_KEY || ''
     : ''
 }


### PR DESCRIPTION
## Problem

The getGrowthBookClientKey function returns empty strings for both dev and production keys, making the function useless. The conditional logic always results in returning an empty string.

**Severity**: `high`
**File**: `src/constants/keys.ts`

## Solution

Either implement proper key retrieval or remove this function. Currently it always returns empty strings regardless of conditions.

## Changes

- `src/constants/keys.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
