### PR TITLE
Quality: Unconditional worktree mode enabled

### DIFF
--- a/src/utils/worktreeModeEnabled.ts
+++ b/src/utils/worktreeModeEnabled.ts
@@ -6,6 +6,4 @@
  * before the cache is populated, silently swallowing --worktree.
  * See https://github.com/anthropics/claude-code/issues/27044.
  */
-export function isWorktreeModeEnabled(): boolean {
-  return true
-}
+export const isWorktreeModeEnabled = true


### PR DESCRIPTION
## Problem

The isWorktreeModeEnabled function always returns true unconditionally. The comment mentions it was previously gated by a GrowthBook flag but the implementation is now a simple constant return.

**Severity**: `medium`
**File**: `src/utils/worktreeModeEnabled.ts`

## Solution

If this is intentionally always enabled, consider using a constant instead of a function. If conditional behavior is needed, implement the proper feature flag logic.

## Changes

- `src/utils/worktreeModeEnabled.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
