### PR TITLE
fix: openaiResponsesToAnthropic usage fallback for OpenAI-compatible APIs

### DIFF
--- a/src/server/proxy/transform/openaiResponsesToAnthropic.ts
+++ b/src/server/proxy/transform/openaiResponsesToAnthropic.ts
@@ -38,8 +38,8 @@ export function openaiResponsesToAnthropic(response: OpenAIResponsesResponse, mo
     stop_reason: mapStatus(response.status, hasToolUse),
     stop_sequence: null,
     usage: {
-      input_tokens: response.usage?.input_tokens || 0,
-      output_tokens: response.usage?.output_tokens || 0,
+      input_tokens: response.usage?.input_tokens ?? response.usage?.prompt_tokens ?? 0,
+      output_tokens: response.usage?.output_tokens ?? response.usage?.completion_tokens ?? 0,
     },
   }
 }


### PR DESCRIPTION
## Summary
- Fixed `openaiResponsesToAnthropic.ts` to support both Anthropic-style (`output_tokens`/`input_tokens`) and OpenAI-standard (`completion_tokens`/`prompt_tokens`) usage field names
- Matches pattern already used in Azure adapter and streaming adapter

## Problem
Non-streaming adapter only read `output_tokens`/`input_tokens` (Anthropic-style fields), but many OpenAI-compatible providers (e.g. Jiutian MoMA returning GLM-5.1) use standard `completion_tokens`/`prompt_tokens`. This caused `Cannot read properties of null (reading 'output_tokens')`.

## Test
- [x] Existing providers (Anthropic-style usage) unchanged (backward compatible)
- [ ] Tested with Jiutian MoMA GLM-5.1 (will verify after merge)

Fixes #383