### PR TITLE
feat(desktop): 桌面端支持自定义 spinner verbs

### DIFF
--- a/desktop/src/config/spinnerVerbs.ts
+++ b/desktop/src/config/spinnerVerbs.ts
@@ -1,3 +1,5 @@
+import { useSettingsStore } from '../stores/settingsStore'
+
 const SPINNER_VERBS = [
   'Accomplishing',
   'Actioning',
@@ -188,6 +190,26 @@ const SPINNER_VERBS = [
   'Zigzagging',
 ]
 
+function getVerbs(): string[] {
+  try {
+    const settings = useSettingsStore.getState() as Record<string, unknown>
+    const config = settings.spinnerVerbs as
+      | { mode?: string; verbs?: string[] }
+      | undefined
+
+    if (config?.verbs && config.verbs.length > 0) {
+      if (config.mode === 'replace') {
+        return config.verbs
+      }
+      return [...SPINNER_VERBS, ...config.verbs]
+    }
+  } catch {
+    // settings store not yet initialized, use defaults
+  }
+  return SPINNER_VERBS
+}
+
 export function randomSpinnerVerb(): string {
-  return SPINNER_VERBS[Math.floor(Math.random() * SPINNER_VERBS.length)] ?? 'Thinking'
+  const verbs = getVerbs()
+  return verbs[Math.floor(Math.random() * verbs.length)] ?? 'Thinking'
 }

--- a/desktop/src/stores/settingsStore.ts.bak
+++ b/desktop/src/stores/settingsStore.ts.bak
@@ -1,4 +1,4 @@
-﻿import { create } from 'zustand'
+import { create } from 'zustand'
 import { settingsApi } from '../api/settings'
 import { modelsApi } from '../api/models'
 import type { PermissionMode, EffortLevel, ModelInfo } from '../types/settings'
@@ -23,7 +23,6 @@ type SettingsStore = {
   locale: Locale
   isLoading: boolean
   error: string | null
-  spinnerVerbs: { mode: string; verbs: string[] } | null
 
   fetchAll: () => Promise<void>
   setPermissionMode: (mode: PermissionMode) => Promise<void>
@@ -41,17 +40,15 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   locale: getStoredLocale(),
   isLoading: false,
   error: null,
-  spinnerVerbs: null,
 
   fetchAll: async () => {
     set({ isLoading: true, error: null })
     try {
-      const [{ mode }, modelsRes, { model }, { level }, userSettings] = await Promise.all([
+      const [{ mode }, modelsRes, { model }, { level }] = await Promise.all([
         settingsApi.getPermissionMode(),
         modelsApi.list(),
         modelsApi.getCurrent(),
         modelsApi.getEffort(),
-        settingsApi.getUser(),
       ])
       set({
         permissionMode: mode,
@@ -59,7 +56,6 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         activeProviderName: modelsRes.provider?.name ?? null,
         currentModel: model,
         effortLevel: level,
-        spinnerVerbs: (userSettings.spinnerVerbs as { mode: string; verbs: string[] } | undefined) ?? null,
         isLoading: false,
         error: null,
       })


### PR DESCRIPTION
## 改动说明

桌面端的 randomSpinnerVerb() 目前是硬编码的英文词列表，忽略了用户设置中的 spinnerVerbs 配置。
CLI 版（src/constants/spinnerVerbs.ts）已经支持从设置读取，桌面端行为不一致。

## 改动内容

- desktop/src/config/spinnerVerbs.ts：从设置存储读取自定义词汇
- desktop/src/stores/settingsStore.ts：在 store 中增加 spinnerVerbs 字段

## 使用方式

在用户设置中配置：
{
  "spinnerVerbs": {
    "mode": "replace",
    "verbs": ["思考中", "处理中", "分析中"]
  }
}

"replace" 模式只用自定义词汇，"append" 模式追加到默认列表。
