### PR TITLE
Fix bundled mode detection for bun-compiled sidecars

### DIFF
--- a/src/utils/__tests__/bundledMode.test.ts
+++ b/src/utils/__tests__/bundledMode.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { isBunVirtualPath, isInBundledMode } from '../bundledMode.js'
+
+const originalArgv = [...process.argv]
+
+afterEach(() => {
+  process.argv = [...originalArgv]
+})
+
+describe('isBunVirtualPath', () => {
+  test('detects POSIX bun virtual filesystem paths', () => {
+    expect(isBunVirtualPath('/$bunfs/root/claude-sidecar')).toBe(true)
+  })
+
+  test('detects Windows bun virtual filesystem paths', () => {
+    expect(isBunVirtualPath('B:\\~BUN\\root\\claude-sidecar.exe')).toBe(true)
+  })
+
+  test('ignores regular filesystem paths', () => {
+    expect(isBunVirtualPath('/Applications/Claude.app/Contents/MacOS/claude-sidecar')).toBe(false)
+  })
+})
+
+describe('isInBundledMode', () => {
+  test('treats bun-compile virtual entrypoints as bundled even when embeddedFiles is empty', () => {
+    process.argv = ['bun', '/$bunfs/root/claude-sidecar']
+
+    expect(Array.isArray(Bun.embeddedFiles)).toBe(true)
+    expect(Bun.embeddedFiles.length).toBe(0)
+    expect(isInBundledMode()).toBe(true)
+  })
+})

--- a/src/utils/bundledMode.ts
+++ b/src/utils/bundledMode.ts
@@ -9,14 +9,31 @@ export function isRunningWithBun(): boolean {
   return process.versions.bun !== undefined
 }
 
+const BUN_VIRTUAL_PATH_MARKERS = ['/$bunfs/', '/~bun/']
+
+export function isBunVirtualPath(candidatePath: string | null | undefined): boolean {
+  if (!candidatePath) {
+    return false
+  }
+
+  const normalized = candidatePath.replace(/\\/g, '/').toLowerCase()
+  return BUN_VIRTUAL_PATH_MARKERS.some(marker => normalized.includes(marker))
+}
+
 /**
  * Detects if running as a Bun-compiled standalone executable.
- * This checks for embedded files which are present in compiled binaries.
+ * Bun compile loads the entry module from Bun's virtual filesystem
+ * (`/$bunfs/...` on POSIX, `~BUN\\...` on Windows). `Bun.embeddedFiles`
+ * alone is not sufficient because compiled binaries can still report an
+ * empty embedded file list at runtime.
  */
 export function isInBundledMode(): boolean {
+  if (typeof Bun === 'undefined') {
+    return false
+  }
+
   return (
-    typeof Bun !== 'undefined' &&
-    Array.isArray(Bun.embeddedFiles) &&
-    Bun.embeddedFiles.length > 0
+    isBunVirtualPath(process.argv[1]) ||
+    (Array.isArray(Bun.embeddedFiles) && Bun.embeddedFiles.length > 0)
   )
 }

--- a/src/utils/ripgrep.ts
+++ b/src/utils/ripgrep.ts
@@ -6,7 +6,7 @@ import { homedir } from 'os'
 import * as path from 'path'
 import { logEvent } from 'src/services/analytics/index.js'
 import { fileURLToPath } from 'url'
-import { isInBundledMode } from './bundledMode.js'
+import { isBunVirtualPath, isInBundledMode } from './bundledMode.js'
 import { logForDebugging } from './debug.js'
 import { isEnvDefinedFalsy } from './envUtils.js'
 import { execFileNoThrow } from './execFileNoThrow.js'
@@ -22,18 +22,11 @@ const __dirname = path.join(
   process.env.NODE_ENV === 'test' ? '../../../' : '../',
 )
 
-const BUN_VIRTUAL_PATH_MARKERS = ['$bunfs', '~BUN']
-
 type RipgrepConfig = {
   mode: 'system' | 'builtin' | 'embedded' | 'unavailable'
   command: string
   args: string[]
   argv0?: string
-}
-
-function isBunVirtualPath(candidatePath: string): boolean {
-  const normalized = candidatePath.replace(/\\/g, '/')
-  return BUN_VIRTUAL_PATH_MARKERS.some(marker => normalized.includes(marker))
 }
 
 export function isUsableBuiltinRipgrepPath(candidatePath: string): boolean {


### PR DESCRIPTION
## Summary

- 修复 `isInBundledMode()` 对 Bun 编译产物的误判，不再只依赖 `Bun.embeddedFiles`
- 通过 Bun 虚拟入口路径识别 bundled mode，确保桌面端 `claude-sidecar` 继续走内嵌 `rg`
- 为 bundled mode 判定补充同区域测试，并复用共享的 Bun 虚拟路径判断逻辑

## Feature Quality Contract

- Changed surface: cli-core / provider-runtime
- Tests added or updated:
  - `bun test ./src/utils/__tests__/bundledMode.test.ts`
  - `bun test ./src/utils/__tests__/ripgrep.test.ts`
- Coverage evidence:
  - 上述定向测试均已通过
  - `bun run verify` 已执行
  - `server-checks` 通过，见 `artifacts/quality-runs/2026-05-14T05-49-29-566Z/logs/server-checks.log`，结果为 `668 pass / 0 fail`
  - 全量 `verify` 当前被 `persistence-upgrade` lane 的仓库既有失败阻断，详见下文
- E2E / live-model evidence:
  - 未执行 live provider / live model
  - 本次修复使用运行时路径单元测试和本地 Bun compile 复现实验作为证据
- Known risk / rollback:
  - 该改动属于 `cli-core`，需要维护者审核并添加 `allow-cli-core-change`
  - 如需回滚，仅需回退本 PR 的 bundled mode 判定改动

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
- [x] I added or updated same-area tests for every production behavior change.
- [ ] I ran `bun run verify` for code changes, including the coverage gate.
- [x] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented.
- [x] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts.
- [x] I ran E2E/live smoke for cross-boundary, provider/runtime, desktop chat, agent-loop, native, or release changes, or documented the blocker.

### 实际执行命令

```bash
bun test ./src/utils/__tests__/bundledMode.test.ts
bun test ./src/utils/__tests__/ripgrep.test.ts
bun run verify
```

### 额外验证证据

- 本地 Bun compile 复现实验（Bun `1.3.14`）：
  - `bun probe.ts` 时，`process.argv[1]` 是真实文件系统脚本路径，且 `Bun.embeddedFiles.length === 0`
  - `bun build --compile probe.ts && ./probe-bin` 时，`process.argv[1]` 变为 `/$bunfs/root/probe-bin`，但 `Bun.embeddedFiles.length === 0`
- 这说明 `Bun.embeddedFiles.length > 0` 不是可靠的 bundled mode 判定条件

### Quality report / blocker

- `bun run verify` 报告目录：
  - `artifacts/quality-runs/2026-05-14T05-49-29-566Z/`
- 已通过的关键 lane：
  - `artifacts/quality-runs/2026-05-14T05-49-29-566Z/logs/server-checks.log`
- 当前 blocker：
  - `artifacts/quality-runs/2026-05-14T05-49-29-566Z/logs/persistence-upgrade.log`
  - `desktop/src/lib/persistenceMigrations.test.ts` 失败，报错为 `TypeError: window.localStorage.clear is not a function`
- 我已在干净的 `origin/main` worktree 上单独执行同一条 desktop 测试，并复现完全相同的失败，说明这是仓库当前基线问题，不是本 PR 引入

## Risk

- [ ] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [x] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`.
- [x] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`.
- [x] Quarantined tests still have owners, exit criteria, and unexpired review windows.
- [x] Provider/runtime changes were covered by mock contract tests, and live smoke was run or explicitly deferred.

@dosubot review this PR for changed-area risk, missing tests, docs impact, desktop startup risk, and CLI core impact.
