### PR TITLE
fix: normalize non-standard errors from anthropic-format 3rd-party APIs

### DIFF
--- a/src/server/proxy/handler.ts
+++ b/src/server/proxy/handler.ts
@@ -53,20 +53,12 @@ export async function handleProxyRequest(req: Request, url: URL): Promise<Respon
     )
   }
 
-  if (config.apiFormat === 'anthropic') {
-    return Response.json(
-      {
-        type: 'error',
-        error: {
-          type: 'invalid_request_error',
-          message: providerId
-            ? `Provider "${providerId}" uses anthropic format — proxy not needed`
-            : 'Active provider uses anthropic format — proxy not needed',
-        },
-      },
-      { status: 400 },
-    )
-  }
+  // Anthropic-format providers also route through the proxy for error
+  // normalization. Third-party APIs often return non-standard error shapes
+  // like {"error":{"message":"...","type":"input_invalid"}} that cause
+  // conversation history corruption and cascade failures if passed through
+  // directly. The passthrough handler normalizes these to proper Anthropic
+  // error format: {type:"error", error:{type:"...", message:"..."}}.
 
   // Parse request body
   let body: AnthropicRequest
@@ -85,8 +77,11 @@ export async function handleProxyRequest(req: Request, url: URL): Promise<Respon
   try {
     if (config.apiFormat === 'openai_chat') {
       return await handleOpenaiChat(body, baseUrl, config.apiKey, isStream)
-    } else {
+    } else if (config.apiFormat === 'openai_responses') {
       return await handleOpenaiResponses(body, baseUrl, config.apiKey, isStream)
+    } else {
+      // anthropic passthrough with error normalization
+      return await handleAnthropicPassthrough(body, baseUrl, config.apiKey, isStream)
     }
   } catch (err) {
     console.error('[Proxy] Upstream request failed:', err)
@@ -215,4 +210,107 @@ async function handleOpenaiResponses(
   const responseBody = await upstream.json()
   const anthropicResponse = openaiResponsesToAnthropic(responseBody, body.model)
   return Response.json(anthropicResponse)
+}
+
+/**
+ * Anthropic passthrough handler — forwards requests as-is to the upstream
+ * Anthropic-compatible API, but intercepts error responses and normalizes them
+ * to proper Anthropic format.
+ *
+ * Many third-party Anthropic-compatible APIs return errors in non-standard
+ * shapes like:
+ *   {"error":{"message":"The input you provided is invalid","type":"input_invalid"}}
+ *
+ * These non-standard errors cause cc-haha's error handler to produce a malformed
+ * AssistantMessage which, when injected into conversation history, triggers a
+ * cascade failure: every subsequent request also fails. Normalizing to the
+ * standard {type:"error", error:{type:"...", message:"..."}} shape prevents
+ * this corruption.
+ */
+async function handleAnthropicPassthrough(
+  body: AnthropicRequest,
+  baseUrl: string,
+  apiKey: string,
+  isStream: boolean,
+): Promise<Response> {
+  const url = `${baseUrl}/v1/messages`
+
+  const upstream = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify(body),
+    signal: isStream ? AbortSignal.timeout(30_000) : AbortSignal.timeout(300_000),
+  })
+
+  if (!upstream.ok) {
+    const errText = await upstream.text().catch(() => '')
+    return Response.json(
+      normalizeAnthropicError(upstream.status, errText),
+      { status: upstream.status },
+    )
+  }
+
+  // Pass through successful response as-is
+  if (isStream) {
+    if (!upstream.body) {
+      return Response.json(
+        { type: 'error', error: { type: 'api_error', message: 'Upstream returned no body for stream' } },
+        { status: 502 },
+      )
+    }
+    return new Response(upstream.body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    })
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * Normalize a non-standard API error response body into proper Anthropic format.
+ *
+ * Recognizes upstream error shapes:
+ *   {"error":{"message":"...","type":"input_invalid"}}  → standard format
+ *   {"error":{"message":"..."}}                          → standard format
+ *   Any other JSON or plain text                         → wrapped as api_error
+ */
+function normalizeAnthropicError(status: number, rawBody: string): {
+  type: string
+  error: { type: string; message: string }
+} {
+  try {
+    const parsed = JSON.parse(rawBody)
+    if (parsed?.error?.message) {
+      const errType = parsed.error.type || 'invalid_request_error'
+      return {
+        type: 'error',
+        error: {
+          type: errType,
+          message: String(parsed.error.message),
+        },
+      }
+    }
+  } catch {
+    // Not JSON — use raw body as message
+  }
+
+  return {
+    type: 'error',
+    error: {
+      type: status >= 500 ? 'api_error' : 'invalid_request_error',
+      message: rawBody.slice(0, 500) || `HTTP ${status}`,
+    },
+  }
 }

--- a/src/server/services/providerService.ts
+++ b/src/server/services/providerService.ts
@@ -347,7 +347,7 @@ export class ProviderService {
     provider: SavedProvider,
     options?: { proxyPath?: string },
   ): Record<string, string> {
-    const needsProxy = provider.apiFormat != null && provider.apiFormat !== 'anthropic'
+    const needsProxy = provider.apiFormat != null
     const proxyPath = options?.proxyPath ?? '/proxy'
     const baseUrl = needsProxy
       ? `http://127.0.0.1:${ProviderService.serverPort}${proxyPath}`
@@ -460,7 +460,7 @@ export class ProviderService {
       const provider = index.providers.find(p => p.id === index.activeId)
       if (provider) {
         const presetDefaultEnv = getPresetDefaultEnv(provider.presetId)
-        const needsProxy = provider.apiFormat != null && provider.apiFormat !== 'anthropic'
+        const needsProxy = provider.apiFormat != null
         const authEnv = buildProviderAuthEnv(provider, presetDefaultEnv, needsProxy)
         if (Object.values(authEnv).some(value => value.length > 0)) {
           return { hasAuth: true, source: 'cc-haha-provider', activeProvider: provider.name }


### PR DESCRIPTION
## Summary
- Routes anthropic-format providers through the local proxy (passthrough mode) instead of bypassing it
- Normalizes non-standard upstream error responses to proper Anthropic format
- Prevents conversation history corruption and cascade failures

## Problem
When using third-party Anthropic-compatible APIs like **step-router-v1**, any API error (image reading, deferred tools, unrecognized tool calls) returns non-standard error shapes:

```json
{"error":{"message":"The input you provided is invalid","type":"input_invalid"}}
```

Since anthropic-format providers bypassed the proxy, these raw errors went straight to cc-haha's error handler. The handler produced a malformed `AssistantMessage` that got injected into conversation history. On subsequent requests, the corrupted history was re-sent to the API → another error → infinite cascade. Only `/clear` could recover.

## Fix
- **handler.ts**: Remove the "proxy not needed" rejection for anthropic format. Add `handleAnthropicPassthrough` that forwards requests/responses through unchanged, but intercepts error responses and normalizes them via `normalizeAnthropicError()` to:
  ```json
  {"type":"error","error":{"type":"invalid_request_error","message":"..."}}
  ```
- **providerService.ts**: Route anthropic-format providers through the proxy (change `needsProxy` condition from `apiFormat != null && apiFormat !== 'anthropic'` to `apiFormat != null`)

## Test plan
- [x] 41 proxy transform + streaming tests pass
- [ ] Test with step-router-v1: trigger image error → text follow-up should work (no cascade)
- [ ] Test with step-router-v1: trigger ToolSearch/deferred tool error → text follow-up should work

## Additional requests
1. **Skills not loading after restart**: After restarting the app, user-installed skills are no longer loaded. This may be a separate issue worth investigating.

2. **OpenAI format support**: Would it be possible to add an OpenAI-format proxy mode that converts Anthropic messages ↔ OpenAI Chat Completions format? This would help providers that only support OpenAI-compatible APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)