### PR TITLE
fix: resume interrupted desktop turns after cli restart

### DIFF
--- a/src/server/__tests__/conversation-service.test.ts
+++ b/src/server/__tests__/conversation-service.test.ts
@@ -290,6 +290,14 @@ describe('ConversationService', () => {
     )
     expect(env.CC_HAHA_DESKTOP_SERVER_URL).toBe('http://127.0.0.1:3456')
     expect(env.CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING).toBe('1')
+    expect(env.CLAUDE_CODE_RESUME_INTERRUPTED_TURN).toBe('1')
+  })
+
+  test('buildChildEnv does not force interrupted-turn resume for non-SDK sessions', async () => {
+    const service = new ConversationService() as any
+    const env = (await service.buildChildEnv('/tmp')) as Record<string, string>
+
+    expect(env.CLAUDE_CODE_RESUME_INTERRUPTED_TURN).toBeUndefined()
   })
 
   test('uses bun entrypoint fallback on Windows dev mode', () => {

--- a/src/server/services/conversationService.ts
+++ b/src/server/services/conversationService.ts
@@ -900,6 +900,16 @@ export class ConversationService {
       CLAUDE_CODE_ENABLE_TASKS: '1',
       CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1',
       CLAUDE_CODE_DIAGNOSTICS_FILE: cliDiagnosticsPath,
+      // Desktop frequently restarts the SDK CLI in-place (stop generation,
+      // runtime/model switch, reconnect). When the previous turn was
+      // interrupted, print.ts only re-enqueues that interrupted user prompt if
+      // this env flag is enabled. Without it, the resumed transcript keeps the
+      // synthetic "[Request interrupted by user]" / "No response requested."
+      // pair, but the interrupted prompt is not actively resumed on restart,
+      // which can make follow-up turns appear to "forget" earlier user input.
+      ...(sdkUrl
+        ? { CLAUDE_CODE_RESUME_INTERRUPTED_TURN: '1' }
+        : {}),
       CALLER_DIR: workDir,
       PWD: workDir,
       ...(sdkUrl


### PR DESCRIPTION
This pull request updates the logic for setting the `CLAUDE_CODE_RESUME_INTERRUPTED_TURN` environment variable in the `ConversationService`. Now, this environment variable is only set when running in SDK sessions, ensuring that interrupted turns are only resumed in that context. The tests have also been updated to verify this behavior.

Environment variable handling:

* Updated `ConversationService` so that `CLAUDE_CODE_RESUME_INTERRUPTED_TURN` is only set to `'1'` when an SDK URL is present, ensuring that interrupted-turn resume is only forced for SDK sessions.

Testing improvements:

* Added a test to confirm that `CLAUDE_CODE_RESUME_INTERRUPTED_TURN` is not set for non-SDK sessions, and updated existing tests to check for its presence in SDK sessions.## Summary

## Feature Quality Contract

- Changed surface: `server` / `provider-runtime` / `desktop chat runtime`
- Tests added or updated:
  - 补充了同区域单元测试
  - 更新 `src/server/__tests__/conversation-service.test.ts`
  - 新增 SDK session 会注入 `CLAUDE_CODE_RESUME_INTERRUPTED_TURN=1` 的断言
  - 新增 non-SDK session 不会误注入该环境变量的断言
- Coverage evidence:
  - 同区域测试：`bun test src/server/__tests__/conversation-service.test.ts`
  - 结果：16 passed / 0 failed
  - 全量 quality gate 报告：`artifacts/quality-runs/2026-05-15T14-29-07-357Z/report.md`
  - coverage 报告：`artifacts/coverage/2026-05-15T14-31-31-634Z/coverage-report.md`
  - 当前 coverage blocker：
    - `server-api` / `agent-tools` / `agent-utils` coverage command exited with 1
    - `changed-lines` 显示 `src/server/services/conversationService.ts` 为 `0% (0/10)`
- E2E / live-model evidence:
  - 已完成浏览器/桌面聊天路径手工复测
  - 复测场景：中断当前生成或切换模型导致 CLI restart 后，后续消息不应“忘记”之前被中断的用户输入
  - 复测 session：`4027e2dc-751f-4d88-90ca-35252e2ab4e4`
  - 未运行 live provider smoke：本次修复聚焦本地 desktop SDK CLI restart/resume 逻辑，未涉及真实 provider 联通性行为变化

修改前测试截图（历史消息会丢失）：
<img width="1928" height="1136" alt="image" src="https://github.com/user-attachments/assets/84956922-af6c-4458-83de-4d41d45a2cd7" />

修改后测试截图（历史消息不丢失）：
  
<img width="1814" height="1176" alt="image" src="https://github.com/user-attachments/assets/51d62034-e80a-4063-a1e1-90a94df735c3" />

- Known risk / rollback:
  - 风险较低，改动仅作用于 desktop SDK child process，在 `sdkUrl` 存在时注入 `CLAUDE_CODE_RESUME_INTERRUPTED_TURN=1`
  - 不影响 non-SDK CLI 启动路径
  - 若出现意外回归，可直接回滚 `src/server/services/conversationService.ts` 中该环境变量注入逻辑

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
- [x] I added or updated same-area tests for every production behavior change.
- [x] I ran `bun run verify` for code changes, including the coverage gate.
- [ ] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented.
- [x] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts.
- [x] I ran E2E/live smoke for cross-boundary, provider/runtime, desktop chat, agent-loop, native, or release changes, or documented the blocker.

Verification notes:

- same-area test passed:
  - `bun test src/server/__tests__/conversation-service.test.ts`
  - result: `16 passed / 0 failed`
- full quality gate:
  - report: `artifacts/quality-runs/2026-05-15T14-29-07-357Z/report.md`
  - junit: `artifacts/quality-runs/2026-05-15T14-29-07-357Z/junit.xml`
  - logs dir: `artifacts/quality-runs/2026-05-15T14-29-07-357Z/logs/`
  - summary: `passed=6 failed=2 skipped=2`
- passed lanes:
  - `impact-report`
  - `policy-checks`
  - `desktop-checks`
  - `native-checks`
  - `persistence-upgrade`
  - `quarantine`
- failed lanes:
  - `server-checks`
  - `coverage`
- current blockers:
  - `coverage` 仍未通过，详见 `artifacts/coverage/2026-05-15T14-31-31-634Z/coverage-report.md`
  - `changed-lines` 对 `src/server/services/conversationService.ts` 仍显示 `0% (0/10)`
  - quality gate 同时标记了 `server-checks` failed，详细原因见对应 lane log

## Risk

- [x] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [x] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`.
- [x] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`.
- [x] Quarantined tests still have owners, exit criteria, and unexpired review windows.
- [x] Provider/runtime changes were covered by mock contract tests, and live smoke was run or explicitly deferred.

Additional notes:

- 该改动没有修改 transcript format、resume 主流程或非-SDK CLI 行为
- 修复目标是 desktop 在 stop generation / runtime switch / reconnect 等触发 CLI in-place restart 的场景下，正确恢复 interrupted turn

@dosubot review this PR for changed-area risk, missing tests, docs impact, desktop startup risk, and CLI core impact.
