### PR TITLE
fix: always accept 'auto' in defaultMode settings schema

### DIFF
--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -57,11 +57,7 @@ export const PermissionsSchema = lazySchema(() =>
           'List of permission rules that should always prompt for confirmation',
         ),
       defaultMode: z
-        .enum(
-          feature('TRANSCRIPT_CLASSIFIER')
-            ? PERMISSION_MODES
-            : EXTERNAL_PERMISSION_MODES,
-        )
+        .enum([...EXTERNAL_PERMISSION_MODES, 'auto'])
         .optional()
         .describe('Default permission mode when Claude Code needs access'),
       disableBypassPermissionsMode: z


### PR DESCRIPTION
## Summary

- Fix `SettingsSchema` to always accept `'auto'` as a valid `permissions.defaultMode` value, regardless of the `TRANSCRIPT_CLASSIFIER` feature flag state.

## Problem

When `TRANSCRIPT_CLASSIFIER` is disabled (sidecar/desktop builds), `defaultMode: 'auto'` in `~/.claude/settings.json` causes Zod validation to fail. This silently discards the **entire** user settings file, resulting in:

- `enabledPlugins` lost → all plugin skills unavailable → "Unknown skill" errors
- `hooks`, `env`, `extraKnownMarketplaces` all lost
- Only project-local `.claude/settings.local.json` is loaded

Users who configured `"defaultMode": "auto"` in the upstream CLI (where the flag is on) cannot use their settings in sidecar builds.

## Fix

Replace the feature-flag-gated enum:
```ts
// Before
defaultMode: z.enum(
  feature('TRANSCRIPT_CLASSIFIER') ? PERMISSION_MODES : EXTERNAL_PERMISSION_MODES,
)

// After
defaultMode: z.enum([...EXTERNAL_PERMISSION_MODES, 'auto'])
```

The schema should accept all valid mode values for file compatibility. Runtime behavior for `auto` mode is separately gated by the feature flag — the schema just needs to not reject the file.

## Test plan

- [x] Verified: sidecar CLI subprocess with `defaultMode: 'auto'` in user settings now correctly loads `enabledPlugins` and all plugin skills
- [x] Verified: `SettingsSchema().safeParse()` no longer returns `success: false` for files containing `defaultMode: 'auto'`