### PR TITLE
优化客户端几乎同时发送 `prewarm_session` 和 `user_message`，`clearPrewarmState` 什么…

### DIFF
--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -547,6 +547,15 @@ async function handlePrewarmSession(ws: ServerWebSocket<WebSocketData>) {
   }
 
   const launchInfo = await sessionService.getSessionLaunchInfo(sessionId).catch(() => null)
+
+  // Re-check after async gap: a user_message may have arrived during the await
+  // and already started (or is starting) the CLI session. If so, skip prewarm
+  // entirely — the user turn owns this session now, and calling markPrewarmed()
+  // would arm an idle timer that later kills the active conversation.
+  if (conversationService.hasSession(sessionId) || sessionStartupPromises.has(sessionId)) {
+    return
+  }
+
   if (launchInfo?.repository) {
     console.log(`[WS] Skipping prewarm for pending repository launch session ${sessionId}`)
     return
@@ -555,7 +564,14 @@ async function handlePrewarmSession(ws: ServerWebSocket<WebSocketData>) {
   prewarmPendingSessions.add(sessionId)
   void ensureCliSessionStarted(ws, sessionId, 'prewarm_session')
     .then(() => {
-      if (!prewarmPendingSessions.delete(sessionId)) return
+      const stillPending = prewarmPendingSessions.delete(sessionId)
+      if (!stillPending) return
+      // Safety: if a user message arrived and activated a turn while we were
+      // waiting for startup, do NOT arm the prewarm idle timer — the session
+      // is now owned by the user conversation, not prewarm.
+      if (isSessionTurnActive(sessionId)) {
+        return
+      }
       bindPrewarmMetadataCapture(sessionId)
       markPrewarmed(sessionId)
     })
@@ -1230,6 +1246,15 @@ function markPrewarmed(sessionId: string) {
   const timer = setTimeout(() => {
     prewarmIdleTimers.delete(sessionId)
     if (!prewarmedSessions.has(sessionId)) return
+    const turnActive = isSessionTurnActive(sessionId)
+    const hasClients = hasActiveClients(sessionId)
+    // Safety guard: never kill a session that has an active user turn or
+    // connected clients. The prewarm idle timer is only meant to reclaim
+    // truly idle prewarmed sessions — not to interrupt an active conversation.
+    if (turnActive || hasClients) {
+      prewarmedSessions.delete(sessionId)
+      return
+    }
     console.log(`[WS] Prewarmed session ${sessionId} idle for ${timeoutMs}ms, stopping CLI subprocess`)
     conversationService.stopSession(sessionId)
     prewarmedSessions.delete(sessionId)


### PR DESCRIPTION
…也没清除，导致kill CLI，客户端永远收不到 `status: idle` 或 error，页面卡在"执行中"

Added safety checks to prevent prewarm idle timer from interrupting active sessions.

## Summary


## Feature Quality Contract

- Changed surface: <!-- desktop / server / adapter / native / docs / provider-runtime / agent-loop / release -->
- Tests added or updated:
  - <!-- e.g. unit/component/API/request-shape/workflow/E2E -->
- Coverage evidence:
  - <!-- coverage report path + relevant suite summary + changed-line coverage -->
- E2E / live-model evidence:
  - <!-- command + report path, or explicit blocker such as no provider/quota -->
- Known risk / rollback:
  - <!-- remaining risk and how to revert safely -->

## Verification

- [ ] I ran the relevant local checks, or explained why they do not apply.
- [ ] I added or updated same-area tests for every production behavior change.
- [ ] I ran `bun run verify` for code changes, including the coverage gate.
- [ ] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented.
- [ ] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts.
- [ ] I ran E2E/live smoke for cross-boundary, provider/runtime, desktop chat, agent-loop, native, or release changes, or documented the blocker.

## Risk

- [ ] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [ ] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`.
- [ ] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`.
- [ ] Quarantined tests still have owners, exit criteria, and unexpired review windows.
- [ ] Provider/runtime changes were covered by mock contract tests, and live smoke was run or explicitly deferred.

@dosubot review this PR for changed-area risk, missing tests, docs impact, desktop startup risk, and CLI core impact.
