### PR TITLE
修复第三方API在响应中返回的model与请求的modelid不一致导致上下文显示200000

### DIFF
--- a/src/server/services/sessionService.ts
+++ b/src/server/services/sessionService.ts
@@ -1390,10 +1390,11 @@ export class SessionService {
 
     for (const providerId of providerIds) {
       const env = await this.providerService.getProviderRuntimeEnv(providerId).catch(() => null)
+	  const rawContextWindows = env?.[MODEL_CONTEXT_WINDOWS_ENV_KEY] ?? null
 	  // Step 1: Try matching the transcript model name directly (current behavior)
       const contextWindow = getModelContextWindowFromEnvValue(
         model,
-        env?.[MODEL_CONTEXT_WINDOWS_ENV_KEY],
+        rawContextWindows,
       )
       if (contextWindow !== undefined) {
         if (contextWindow > MODEL_CONTEXT_WINDOW_DEFAULT && is1mContextDisabled()) {
@@ -1443,10 +1444,11 @@ export class SessionService {
 
     for (const provider of providers) {
       const env = await this.providerService.getProviderRuntimeEnv(provider.id).catch(() => null)
+	  const rawContextWindows = env?.[MODEL_CONTEXT_WINDOWS_ENV_KEY] ?? null
       // Step 1: Try matching the transcript model name directly
 	  const contextWindow = getModelContextWindowFromEnvValue(
         model,
-        env?.[MODEL_CONTEXT_WINDOWS_ENV_KEY],
+        rawContextWindows,
       )
       if (contextWindow !== undefined) {
         matches.push(contextWindow)
@@ -1463,12 +1465,6 @@ export class SessionService {
             rawContextWindows,
           )
           if (fallbackWindow !== undefined) {
-            traceDebug('CTX_WIN', 'getUniqueSavedProviderContextWindow — fallback match via configured model', {
-              transcriptModel: model,
-              configuredModel,
-              envKey,
-              fallbackWindow,
-            })
             matches.push(fallbackWindow)
             break // One match per provider is enough
           }

--- a/src/server/services/sessionService.ts
+++ b/src/server/services/sessionService.ts
@@ -1376,8 +1376,21 @@ export class SessionService {
       if (activeId) providerIds.push(activeId)
     }
 
+    // Provider env model keys — these are the configured model names that
+    // should be used as fallback matching keys when the transcript model name
+    // (from the API response) doesn't match the modelContextWindows keys.
+    // Third-party APIs may return model names with provider-specific suffixes
+    // (e.g. "LongCat-2.0-Preview-LongCatAI" instead of "LongCat-2.0-Preview").
+    const providerEnvModelKeys = [
+      'ANTHROPIC_MODEL',
+      'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+      'ANTHROPIC_DEFAULT_SONNET_MODEL',
+      'ANTHROPIC_DEFAULT_OPUS_MODEL',
+    ] as const
+
     for (const providerId of providerIds) {
       const env = await this.providerService.getProviderRuntimeEnv(providerId).catch(() => null)
+	  // Step 1: Try matching the transcript model name directly (current behavior)
       const contextWindow = getModelContextWindowFromEnvValue(
         model,
         env?.[MODEL_CONTEXT_WINDOWS_ENV_KEY],
@@ -1387,6 +1400,27 @@ export class SessionService {
           return MODEL_CONTEXT_WINDOW_DEFAULT
         }
         return contextWindow
+      }
+	  // Step 2: If transcript model name didn't match, try matching with
+      // the provider's configured model names as fallback keys.
+      // This handles the case where the API response returns a model name
+      // that differs from the user-configured model name (e.g. provider
+      // appends its own suffix like "-LongCatAI").
+      if (env && rawContextWindows) {
+        for (const envKey of providerEnvModelKeys) {
+          const configuredModel = env[envKey]
+          if (!configuredModel) continue
+          const fallbackWindow = getModelContextWindowFromEnvValue(
+            configuredModel,
+            rawContextWindows,
+          )
+          if (fallbackWindow !== undefined) {
+            if (fallbackWindow > MODEL_CONTEXT_WINDOW_DEFAULT && is1mContextDisabled()) {
+              return MODEL_CONTEXT_WINDOW_DEFAULT
+            }
+            return fallbackWindow
+          }
+        }
       }
     }
 
@@ -1400,15 +1434,45 @@ export class SessionService {
   private async getUniqueSavedProviderContextWindow(model: string): Promise<number | undefined> {
     const { providers } = await this.providerService.listProviders().catch(() => ({ providers: [] }))
     const matches: number[] = []
+	const providerEnvModelKeys = [
+      'ANTHROPIC_MODEL',
+      'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+      'ANTHROPIC_DEFAULT_SONNET_MODEL',
+      'ANTHROPIC_DEFAULT_OPUS_MODEL',
+    ] as const
 
     for (const provider of providers) {
       const env = await this.providerService.getProviderRuntimeEnv(provider.id).catch(() => null)
-      const contextWindow = getModelContextWindowFromEnvValue(
+      // Step 1: Try matching the transcript model name directly
+	  const contextWindow = getModelContextWindowFromEnvValue(
         model,
         env?.[MODEL_CONTEXT_WINDOWS_ENV_KEY],
       )
       if (contextWindow !== undefined) {
         matches.push(contextWindow)
+        continue
+      }
+
+      // Step 2: Fallback — try matching with provider's configured model names
+      if (env && rawContextWindows) {
+        for (const envKey of providerEnvModelKeys) {
+          const configuredModel = env[envKey]
+          if (!configuredModel) continue
+          const fallbackWindow = getModelContextWindowFromEnvValue(
+            configuredModel,
+            rawContextWindows,
+          )
+          if (fallbackWindow !== undefined) {
+            traceDebug('CTX_WIN', 'getUniqueSavedProviderContextWindow — fallback match via configured model', {
+              transcriptModel: model,
+              configuredModel,
+              envKey,
+              fallbackWindow,
+            })
+            matches.push(fallbackWindow)
+            break // One match per provider is enough
+          }
+        }
       }
     }
 


### PR DESCRIPTION
修复第三方API在响应中返回的model与请求的modelid不一致导致上下文显示200000

## Summary


## Feature Quality Contract

- Changed surface: <!-- desktop / server / adapter / native / docs / provider-runtime / agent-loop / release -->
- Tests added or updated:
  - <!-- e.g. unit/component/API/request-shape/workflow/E2E -->
- Coverage evidence:
  - <!-- coverage report path + relevant suite summary + changed-line coverage -->
- E2E / live-model evidence:
  - <!-- command + report path, or explicit blocker such as no provider/quota -->
- Known risk / rollback:
  - <!-- remaining risk and how to revert safely -->

## Verification

- [ ] I ran the relevant local checks, or explained why they do not apply.
- [ ] I added or updated same-area tests for every production behavior change.
- [ ] I ran `bun run verify` for code changes, including the coverage gate.
- [ ] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented.
- [ ] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts.
- [ ] I ran E2E/live smoke for cross-boundary, provider/runtime, desktop chat, agent-loop, native, or release changes, or documented the blocker.

## Risk

- [ ] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [ ] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`.
- [ ] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`.
- [ ] Quarantined tests still have owners, exit criteria, and unexpired review windows.
- [ ] Provider/runtime changes were covered by mock contract tests, and live smoke was run or explicitly deferred.

@dosubot review this PR for changed-area risk, missing tests, docs impact, desktop startup risk, and CLI core impact.
