### PR TITLE
优化trace加载页大小，增加清空按钮

### DIFF
--- a/desktop/src/api/traces.ts
+++ b/desktop/src/api/traces.ts
@@ -18,4 +18,8 @@ export const tracesApi = {
   updateSettings(settings: Partial<Pick<TraceCaptureSettings, 'enabled'>>) {
     return api.put<TraceCaptureSettings>('/api/traces/settings', settings)
   },
+
+  purgeAll() {
+    return api.delete<{ removed: number }>('/api/traces')
+  },
 }

--- a/desktop/src/i18n/locales/en.ts
+++ b/desktop/src/i18n/locales/en.ts
@@ -1844,6 +1844,10 @@ export const en = {
   'trace.list.loadFailed': 'Failed to load trace list',
   'trace.list.loadedCount': 'Showing {shown} of {total}',
   'trace.list.loadMore': 'Load more',
+  'trace.list.clearAll': 'Clear all',
+  'trace.list.clearAllConfirm': 'Are you sure you want to delete all trace records? This action cannot be undone.',
+  'trace.list.purgeSuccess': 'Cleared {count} trace records',
+  'trace.list.purgeFailed': 'Failed to clear trace records',
 
   // ─── App Shell ──────────────────────────────────────
   'app.serverFailed': 'Local server failed to start',

--- a/desktop/src/i18n/locales/jp.ts
+++ b/desktop/src/i18n/locales/jp.ts
@@ -1846,6 +1846,10 @@ export const jp: Record<TranslationKey, string> = {
   'trace.list.loadFailed': 'Trace 一覧の読み込みに失敗しました',
   'trace.list.loadedCount': '{shown} / {total} を表示中',
   'trace.list.loadMore': 'さらに読み込む',
+  'trace.list.clearAll': 'すべて削除',
+  'trace.list.clearAllConfirm': 'すべての trace レコードを削除しますか？この操作は取り消せません。',
+  'trace.list.purgeSuccess': '{count}件の trace レコードを削除しました',
+  'trace.list.purgeFailed': 'trace レコードの削除に失敗しました',
 
   // ─── App Shell ──────────────────────────────────────
   'app.serverFailed': 'ローカルサーバーの起動に失敗しました',

--- a/desktop/src/i18n/locales/kr.ts
+++ b/desktop/src/i18n/locales/kr.ts
@@ -1846,6 +1846,10 @@ export const kr: Record<TranslationKey, string> = {
   'trace.list.loadFailed': 'Trace 목록을 불러오지 못했습니다',
   'trace.list.loadedCount': '{shown} / {total} 표시 중',
   'trace.list.loadMore': '더 불러오기',
+  'trace.list.clearAll': '모두 삭제',
+  'trace.list.clearAllConfirm': '모든 trace 레코드를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.',
+  'trace.list.purgeSuccess': '{count}개 trace 레코드 삭제 완료',
+  'trace.list.purgeFailed': 'trace 레코드 삭제 실패',
 
   // ─── App Shell ──────────────────────────────────────
   'app.serverFailed': '로컬 서버를 시작하지 못했습니다',

--- a/desktop/src/i18n/locales/zh-TW.ts
+++ b/desktop/src/i18n/locales/zh-TW.ts
@@ -1846,6 +1846,10 @@ export const zh: Record<TranslationKey, string> = {
   'trace.list.loadFailed': 'Trace 列表載入失敗',
   'trace.list.loadedCount': '已顯示 {shown} / {total}',
   'trace.list.loadMore': '載入更多',
+  'trace.list.clearAll': '清空所有',
+  'trace.list.clearAllConfirm': '確定要刪除所有 trace 記錄嗎？此操作不可撤銷。',
+  'trace.list.purgeSuccess': '已清空 {count} 條 trace 記錄',
+  'trace.list.purgeFailed': '清空 trace 記錄失敗',
 
   // ─── 應用外殼 ──────────────────────────────────────
   'app.serverFailed': '本地服務啟動失敗',

--- a/desktop/src/i18n/locales/zh.ts
+++ b/desktop/src/i18n/locales/zh.ts
@@ -1846,6 +1846,10 @@ export const zh: Record<TranslationKey, string> = {
   'trace.list.loadFailed': 'Trace 列表加载失败',
   'trace.list.loadedCount': '已显示 {shown} / {total}',
   'trace.list.loadMore': '加载更多',
+  'trace.list.clearAll': '清空所有',
+  'trace.list.clearAllConfirm': '确定要删除所有 trace 记录吗？此操作不可撤销。',
+  'trace.list.purgeSuccess': '已清空 {count} 条 trace 记录',
+  'trace.list.purgeFailed': '清空 trace 记录失败',
 
   // ─── 应用外壳 ──────────────────────────────────────
   'app.serverFailed': '本地服务启动失败',

--- a/desktop/src/pages/TraceList.tsx
+++ b/desktop/src/pages/TraceList.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
-import { ExternalLink, RefreshCw, Search, Workflow } from 'lucide-react'
+import { ExternalLink, RefreshCw, Search, Trash2, Workflow } from 'lucide-react'
 import { tracesApi } from '../api/traces'
 import { SETTINGS_TAB_ID, useTabStore } from '../stores/tabStore'
 import { useUIStore } from '../stores/uiStore'
 import { useTranslation } from '../i18n'
 import { Button } from '../components/shared/Button'
+import { ConfirmDialog } from '../components/shared/ConfirmDialog'
 import { getDesktopHost } from '../lib/desktopHost'
 import type { TraceSessionList, TraceSessionListItem } from '../types/trace'
 
@@ -22,10 +23,13 @@ const MAX_MODEL_CHIPS = 2
 
 export function TraceList() {
   const t = useTranslation()
+  const addToast = useUIStore((s) => s.addToast)
   const [state, setState] = useState<TraceListState>({ status: 'loading' })
   const [queryInput, setQueryInput] = useState('')
   const [query, setQuery] = useState('')
   const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [isPurging, setIsPurging] = useState(false)
+  const [purgeConfirmOpen, setPurgeConfirmOpen] = useState(false)
   const host = getDesktopHost()
 
   useEffect(() => {
@@ -72,6 +76,21 @@ export function TraceList() {
       if (append) setIsLoadingMore(false)
     }
   }, [query, t])
+
+  const handlePurge = useCallback(async () => {
+    setIsPurging(true)
+    try {
+      const result = await tracesApi.purgeAll()
+      addToast({ type: 'success', message: t('trace.list.purgeSuccess', { count: result.removed }) })
+      setState({ status: 'loading' })
+      await load()
+    } catch (error) {
+      addToast({ type: 'error', message: error instanceof Error ? error.message : t('trace.list.purgeFailed') })
+    } finally {
+      setIsPurging(false)
+      setPurgeConfirmOpen(false)
+    }
+  }, [load, addToast, t])
 
   useEffect(() => {
     void load()
@@ -136,6 +155,12 @@ export function TraceList() {
               <RefreshCw className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
               {t('trace.refresh')}
             </Button>
+            {state.status === 'ready' && state.data.total > 0 && (
+              <Button size="sm" variant="danger" onClick={() => setPurgeConfirmOpen(true)} disabled={isPurging}>
+                <Trash2 className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+                {t('trace.list.clearAll')}
+              </Button>
+            )}
           </div>
         </div>
 
@@ -182,6 +207,17 @@ export function TraceList() {
           />
         )}
       </div>
+      <ConfirmDialog
+        open={purgeConfirmOpen}
+        onClose={() => { if (!isPurging) setPurgeConfirmOpen(false) }}
+        onConfirm={() => void handlePurge()}
+        title={t('trace.list.clearAll')}
+        body={t('trace.list.clearAllConfirm')}
+        confirmLabel={t('trace.list.clearAll')}
+        cancelLabel={t('common.cancel')}
+        confirmVariant="danger"
+        loading={isPurging}
+      />
     </div>
   )
 }

--- a/desktop/src/pages/TraceList.tsx
+++ b/desktop/src/pages/TraceList.tsx
@@ -15,7 +15,7 @@ type TraceListState =
   | { status: 'ready'; data: TraceSessionList }
 
 const POLL_MS = 5_000
-const PAGE_SIZE = 50
+const PAGE_SIZE = 10
 const SEARCH_DEBOUNCE_MS = 250
 const MAX_MODEL_CHIPS = 2
 

--- a/src/server/api/traces.ts
+++ b/src/server/api/traces.ts
@@ -4,6 +4,7 @@ import {
   readTraceCaptureSettings,
   traceCaptureService,
   updateTraceCaptureSettings,
+  purgeAllTraces,
   type TraceSessionFileItem,
   type TraceSessionListItem,
 } from '../services/traceCaptureService.js'
@@ -44,8 +45,9 @@ export async function handleTracesApi(
 
     switch (sub) {
       case undefined:
-        if (req.method !== 'GET') throw methodNotAllowed(req.method, '/api/traces')
-        return await listTraces(url)
+        if (req.method === 'GET') return await listTraces(url)
+        if (req.method === 'DELETE') return await purgeTraces()
+        throw methodNotAllowed(req.method, '/api/traces')
 
       case 'settings':
         if (req.method === 'GET') {
@@ -65,6 +67,11 @@ export async function handleTracesApi(
   } catch (error) {
     return errorResponse(error)
   }
+}
+
+async function purgeTraces(): Promise<Response> {
+  const result = await purgeAllTraces()
+  return Response.json({ removed: result.removed })
 }
 
 async function listTraces(url: URL): Promise<Response> {

--- a/src/server/services/traceCaptureService.ts
+++ b/src/server/services/traceCaptureService.ts
@@ -15,6 +15,7 @@ export {
   trimTraceCallPreviews,
   updateTraceCaptureSettings,
 } from '../../services/api/traceCapture.js'
+export { purgeAllTraces } from '../../services/api/traceCapture.js'
 export type {
   RecordTraceCallInput,
   RecordTraceEventInput,

--- a/src/services/api/traceCapture.ts
+++ b/src/services/api/traceCapture.ts
@@ -294,6 +294,24 @@ export function createTraceCallId(): string {
   return randomUUID()
 }
 
+export async function purgeAllTraces(): Promise<{ removed: number }> {
+  const storageDir = getTraceStorageDir()
+  let entries: string[] = []
+  try {
+    entries = await fs.readdir(storageDir)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { removed: 0 }
+    throw error
+  }
+  const files = entries.filter((name) => name.endsWith('.jsonl'))
+  for (const name of files) {
+    await fs.unlink(join(storageDir, name)).catch(() => {})
+  }
+  traceReadCache.clear()
+  traceWriteQueues.clear()
+  return { removed: files.length }
+}
+
 class TraceCaptureService {
   async recordCall(input: RecordTraceCallInput): Promise<TraceCallRecord | null> {
     if (!input.sessionId.trim()) return null


### PR DESCRIPTION
优化trace加载页大小，增加清空按钮

## Summary


## Feature Quality Contract

- Changed surface: <!-- desktop / server / adapter / native / docs / provider-runtime / agent-loop / release -->
- Tests added or updated:
  - <!-- e.g. unit/component/API/request-shape/workflow/E2E -->
- Coverage evidence:
  - <!-- coverage report path + relevant suite summary + changed-line coverage -->
- E2E / live-model evidence:
  - <!-- command + report path, or explicit blocker such as no provider/quota -->
- Known risk / rollback:
  - <!-- remaining risk and how to revert safely -->

## Verification

- [ ] I ran the relevant local checks, or explained why they do not apply.
- [ ] I added or updated same-area tests for every production behavior change.
- [ ] I ran `bun run verify` for code changes, including the coverage gate.
- [ ] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented.
- [ ] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts.
- [ ] I ran E2E/live smoke for cross-boundary, provider/runtime, desktop chat, agent-loop, native, or release changes, or documented the blocker.

## Risk

- [ ] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [ ] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`.
- [ ] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`.
- [ ] Quarantined tests still have owners, exit criteria, and unexpired review windows.
- [ ] Provider/runtime changes were covered by mock contract tests, and live smoke was run or explicitly deferred.

@dosubot review this PR for changed-area risk, missing tests, docs impact, desktop startup risk, and CLI core impact.
