### PR TITLE
Fix issue #964: Prevent starting terminal if already starting

### DIFF
--- a/desktop/src/pages/TerminalSettings.tsx
+++ b/desktop/src/pages/TerminalSettings.tsx
@@ -151,6 +151,9 @@ export function TerminalSettings({
   }, [runtime])
 
   const startTerminal = useCallback(async () => {
+    
+    if (runtime.status === 'starting') return
+
     if (!terminalApi.isAvailable()) {
       updateTerminalRuntime(runtime, { status: 'unavailable' })
       return


### PR DESCRIPTION
## Summary


## Feature Quality Contract

- Changed surface: desktop 
- Tests added or updated:
  - E2E 
- Coverage evidence:
  - <!-- coverage report path + relevant suite summary + changed-line coverage -->
- E2E / live-model evidence:
 The issue root cause is no guard protection for startTerminal
After code add, local verify correct
<img width="1880" height="1965" alt="image" src="https://github.com/user-attachments/assets/cd86b2c6-ca0a-4302-b113-27c8f711ae2a" />

- Known risk / rollback:
  - <!-- remaining risk and how to revert safely -->

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
- [ ] I added or updated same-area tests for every production behavior change.
- [x] I ran `bun run verify` for code changes, including the coverage gate.
- [ ] New or changed executable production lines meet the changed-line coverage threshold, or the blocker/maintainer override is documented.
- [ ] I attached or summarized the quality report path, JUnit/log artifact path, and pass/fail/skip counts.
- [x] I ran E2E/live smoke for cross-boundary, provider/runtime, desktop chat, agent-loop, native, or release changes, or documented the blocker.

## Risk

- [x] This PR does not touch CLI core paths, or it has maintainer approval for `allow-cli-core-change`.
- [ ] Production code changes include matching tests, or have maintainer approval for `allow-missing-tests`.
- [ ] Coverage baseline/threshold changes have maintainer approval for `allow-coverage-baseline-change`.
- [ ] Quarantined tests still have owners, exit criteria, and unexpired review windows.
- [ ] Provider/runtime changes were covered by mock contract tests, and live smoke was run or explicitly deferred.

@dosubot review this PR for changed-area risk, missing tests, docs impact, desktop startup risk, and CLI core impact.
