### PR TITLE
fix(proxy): 保留 Responses 工具结果中的图片

### DIFF
--- a/src/server/__tests__/proxy-transform.test.ts
+++ b/src/server/__tests__/proxy-transform.test.ts
@@ -542,12 +542,151 @@ describe('anthropicToOpenaiResponses', () => {
       }],
     }
     const result = anthropicToOpenaiResponses(req)
-    const fco = result.input.find((i) => i.type === 'function_call_output')
-    expect(fco).toBeDefined()
-    if (fco && fco.type === 'function_call_output') {
-      expect(fco.call_id).toBe('tc_1')
-      expect(fco.output).toBe('found it')
+    expect(result.input).toEqual([{
+      type: 'function_call_output',
+      call_id: 'tc_1',
+      output: 'found it',
+    }])
+  })
+
+  test('preserves text-only tool_result arrays as strings', () => {
+    const req: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 100,
+      messages: [{
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'tc_2',
+          content: [
+            { type: 'text', text: 'first' },
+            { type: 'text', text: 'second' },
+          ],
+        }],
+      }],
     }
+
+    const result = anthropicToOpenaiResponses(req)
+
+    expect(result.input).toEqual([{
+      type: 'function_call_output',
+      call_id: 'tc_2',
+      output: 'first\nsecond',
+    }])
+  })
+
+  test('preserves image-only tool_result content', () => {
+    const req: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 100,
+      messages: [{
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'read_1',
+          content: [{
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'AAECAwQ=' },
+          }],
+        }],
+      }],
+    }
+
+    const result = anthropicToOpenaiResponses(req)
+
+    expect(result.input).toEqual([{
+      type: 'function_call_output',
+      call_id: 'read_1',
+      output: [{
+        type: 'input_image',
+        image_url: 'data:image/png;base64,AAECAwQ=',
+      }],
+    }])
+  })
+
+  test('preserves mixed tool_result content in order', () => {
+    const req: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 100,
+      messages: [{
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'read_2',
+          content: [
+            { type: 'text', text: 'before' },
+            {
+              type: 'image',
+              source: { type: 'base64', media_type: 'image/jpeg', data: '/9j/AA==' },
+            },
+            { type: 'text', text: 'after' },
+          ],
+        }],
+      }],
+    }
+
+    const result = anthropicToOpenaiResponses(req)
+
+    expect(result.input).toEqual([{
+      type: 'function_call_output',
+      call_id: 'read_2',
+      output: [
+        { type: 'input_text', text: 'before' },
+        { type: 'input_image', image_url: 'data:image/jpeg;base64,/9j/AA==' },
+        { type: 'input_text', text: 'after' },
+      ],
+    }])
+  })
+
+  test('preserves message and tool_result item order', () => {
+    const req: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 100,
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'before result' },
+          { type: 'tool_result', tool_use_id: 'read_3', content: 'result' },
+          { type: 'text', text: 'after result' },
+        ],
+      }],
+    }
+
+    const result = anthropicToOpenaiResponses(req)
+
+    expect(result.input).toEqual([
+      { type: 'message', role: 'user', content: 'before result' },
+      { type: 'function_call_output', call_id: 'read_3', output: 'result' },
+      { type: 'message', role: 'user', content: 'after result' },
+    ])
+  })
+
+  test('preserves mixed text and image message content', () => {
+    const req: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 100,
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image' },
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'AAECAwQ=' },
+          },
+        ],
+      }],
+    }
+
+    const result = anthropicToOpenaiResponses(req)
+
+    expect(result.input).toEqual([{
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'Describe this image' },
+        { type: 'input_image', image_url: 'data:image/png;base64,AAECAwQ=' },
+      ],
+    }])
   })
 
   test('thinking → reasoning', () => {

--- a/src/server/proxy/transform/anthropicToOpenaiResponses.ts
+++ b/src/server/proxy/transform/anthropicToOpenaiResponses.ts
@@ -10,7 +10,7 @@ import type {
   AnthropicMessage,
   OpenAIResponsesRequest,
   OpenAIResponsesInputItem,
-  OpenAIChatContentPart,
+  OpenAIResponsesInputContentPart,
 } from './types.js'
 import { stripLeadingBillingHeader } from './billingHeader.js'
 import { normalizeOpenAIReasoningEffort } from './effort.js'
@@ -106,6 +106,19 @@ export function anthropicToOpenaiResponses(
   return result
 }
 
+function convertContentBlock(
+  block: Extract<AnthropicContentBlock, { type: 'text' | 'image' }>,
+): OpenAIResponsesInputContentPart {
+  if (block.type === 'text') {
+    return { type: 'input_text', text: block.text }
+  }
+
+  return {
+    type: 'input_image',
+    image_url: `data:${block.source.media_type};base64,${block.source.data}`,
+  }
+}
+
 function convertMessageToInputItems(msg: AnthropicMessage, output: OpenAIResponsesInputItem[]): void {
   const content = msg.content
 
@@ -121,27 +134,28 @@ function convertMessageToInputItems(msg: AnthropicMessage, output: OpenAIRespons
   }
 
   // Collect text/image parts and handle tool blocks separately
-  const contentParts: (string | OpenAIChatContentPart)[] = []
+  const contentParts: OpenAIResponsesInputContentPart[] = []
+
+  const flushContentParts = (): void => {
+    if (contentParts.length === 0) return
+
+    if (contentParts.every((part) => part.type === 'input_text')) {
+      const messageContent = contentParts.map((part) => part.text).join('')
+      if (messageContent) {
+        output.push({ type: 'message', role: msg.role, content: messageContent })
+      }
+    } else {
+      output.push({ type: 'message', role: msg.role, content: [...contentParts] })
+    }
+    contentParts.length = 0
+  }
 
   for (const block of content) {
-    if (block.type === 'text') {
-      contentParts.push(block.text)
-    } else if (block.type === 'image') {
-      contentParts.push({
-        type: 'image_url',
-        image_url: { url: `data:${block.source.media_type};base64,${block.source.data}` },
-      })
+    if (block.type === 'text' || block.type === 'image') {
+      contentParts.push(convertContentBlock(block))
     } else if (block.type === 'tool_use') {
       // Flush any accumulated content first
-      if (contentParts.length > 0) {
-        const flatContent = contentParts.length === 1 && typeof contentParts[0] === 'string'
-          ? contentParts[0]
-          : contentParts.map((p) => typeof p === 'string' ? p : '').join('')
-        if (flatContent) {
-          output.push({ type: 'message', role: msg.role, content: flatContent })
-        }
-        contentParts.length = 0
-      }
+      flushContentParts()
       // Lift to function_call item
       output.push({
         type: 'function_call',
@@ -150,30 +164,30 @@ function convertMessageToInputItems(msg: AnthropicMessage, output: OpenAIRespons
         arguments: typeof block.input === 'string' ? block.input : JSON.stringify(block.input),
       })
     } else if (block.type === 'tool_result') {
+      // Flush any accumulated content first
+      flushContentParts()
       // Lift to function_call_output item
       const resultContent = typeof block.content === 'string'
         ? block.content
         : Array.isArray(block.content)
-          ? block.content.filter((b): b is Extract<AnthropicContentBlock, { type: 'text' }> => b.type === 'text').map((b) => b.text).join('\n')
+          ? block.content.filter((part): part is Extract<AnthropicContentBlock, { type: 'text' | 'image' }> => (
+              part.type === 'text' || part.type === 'image'
+            )).map(convertContentBlock)
           : ''
+      const resultOutput = Array.isArray(resultContent) && resultContent.every((part) => part.type === 'input_text')
+        ? resultContent.map((part) => part.text).join('\n')
+        : resultContent
       output.push({
         type: 'function_call_output',
         call_id: block.tool_use_id,
-        output: resultContent,
+        output: resultOutput,
       })
     }
     // Skip thinking blocks
   }
 
   // Flush remaining content
-  if (contentParts.length > 0) {
-    const flatContent = contentParts.length === 1 && typeof contentParts[0] === 'string'
-      ? contentParts[0]
-      : contentParts.map((p) => typeof p === 'string' ? p : '').join('')
-    if (flatContent) {
-      output.push({ type: 'message', role: msg.role, content: flatContent })
-    }
-  }
+  flushContentParts()
 }
 
 function convertToolChoice(choice: unknown): unknown {

--- a/src/server/proxy/transform/types.ts
+++ b/src/server/proxy/transform/types.ts
@@ -117,10 +117,14 @@ export type OpenAIChatStreamChunk = {
 
 // ─── OpenAI Responses API ───────────────────────────────────
 
+export type OpenAIResponsesInputContentPart =
+  | { type: 'input_text'; text: string }
+  | { type: 'input_image'; image_url: string }
+
 export type OpenAIResponsesInputItem =
-  | { type: 'message'; role: 'user' | 'assistant' | 'system'; content: string | OpenAIChatContentPart[] }
+  | { type: 'message'; role: 'user' | 'assistant' | 'system'; content: string | OpenAIResponsesInputContentPart[] }
   | { type: 'function_call'; call_id: string; name: string; arguments: unknown }
-  | { type: 'function_call_output'; call_id: string; output: string }
+  | { type: 'function_call_output'; call_id: string; output: string | OpenAIResponsesInputContentPart[] }
 
 export type OpenAIResponsesRequest = {
   model: string


### PR DESCRIPTION
## 摘要

- 修正 OpenAI Responses 请求转换中图片内容使用了 Chat Completions 结构的问题。
- 保留工具结果中的纯图片和图文混合内容，避免 `Read` 等工具返回的图片被过滤成空字符串。
- 在输出工具结果前刷新普通消息内容，保持消息与工具结果的原始顺序。
- 继续将纯字符串和纯文本数组工具结果转换为字符串，避免破坏现有兼容性。

## Feature Quality Contract

- Changed surface: server / provider-runtime
- Tests added or updated:
  - 更新 `proxy-transform.test.ts` 的请求结构断言。
  - 新增纯文本数组、纯图片、图文混合、消息与工具结果顺序、普通图文消息回归测试。
- Coverage evidence:
  - `bun test --cwd D:/ai/cc-haha --no-env-file --coverage --coverage-reporter=lcov --coverage-reporter=text --coverage-dir D:/ai/cc-haha/artifacts/local-proxy-transform-coverage ./src/server/__tests__/proxy-transform.test.ts`
  - 结果：73 passed / 0 failed；测试文件 100% 行覆盖，`anthropicToOpenaiResponses.ts` 行覆盖率 88.64%。
  - 本地报告：`artifacts/coverage/2026-07-17T04-30-01-088Z/coverage-report.md`。
- E2E / live-model evidence:
  - 未运行真实模型验证（来自 fork，未使用真实 provider 或额度）。
- Known risk / rollback:
  - 仅影响 `openai_responses` 请求转换。若兼容服务不支持多模态 `function_call_output.output`，可回滚本提交恢复旧行为。

## Verification

- [x] focused transform tests：73 passed / 0 failed。
- [x] `check:impact` 使用 3 个实际改动文件计算，选择 `check:server`、`check:provider-contract`、`check:coverage`。
- [x] 与本改动直接相关的 provider contract 转换套件：73 passed / 0 failed。
- [x] 新增测试逐项断言 `call_id`、内容类型、媒体类型、base64 data URL 和内容顺序。
- [ ] `check:provider-contract` 全量：被既有 Windows 环境变量大小写问题阻塞。`src/utils/proxy.test.ts` 中删除 `no_proxy` 会同时删除 `NO_PROXY`，导致 3 个无关代理断言失败。
- [ ] `check:server` 全量：被既有 Windows 测试环境问题阻塞，包括终端 shell 环境继承断言，以及临时目录清理时的 `EBUSY`。
- [ ] `check:coverage` 全量：当前 Windows/Bun 环境发现 189 个 root 测试文件但执行时匹配为 0；adapters/desktop lane 另有既有环境错误。focused coverage 已单独通过。
- [ ] `bun run verify`：未重复运行，因为其选中的上述全量 lane 已确认受到同一环境问题阻塞。

## Risk

- [x] 生产代码改动包含同区域回归测试。
- [x] Provider/runtime 改动已由离线请求结构测试覆盖。
- [x] 未修改持久化格式、桌面 UI、Chat Completions 转换或响应转换。
- [x] 未新增依赖。