### PR TITLE
feat: side session panel + new session model inheritance

### DIFF
--- a/desktop/src/components/chat/ChatInput.tsx
+++ b/desktop/src/components/chat/ChatInput.tsx
@@ -19,8 +19,8 @@ import { ModelSelector, type ModelSelectorHandle } from '../controls/ModelSelect
 import type { AttachmentRef } from '../../types/chat'
 import { AttachmentGallery } from './AttachmentGallery'
 import { ComposerDropOverlay } from './ComposerDropOverlay'
-import { ProjectContextChip } from '../shared/ProjectContextChip'
 import { RepositoryLaunchControls } from '../shared/RepositoryLaunchControls'
+import { ProjectContextChip } from '../shared/ProjectContextChip'
 import { FileSearchMenu, type FileSearchMenuHandle } from './FileSearchMenu'
 import { LocalSlashCommandPanel, type LocalSlashCommandName } from './LocalSlashCommandPanel'
 import { ContextUsageIndicator } from './ContextUsageIndicator'
@@ -44,7 +44,6 @@ import {
 import { useComposerFileDrop } from './useComposerFileDrop'
 import { shouldSubmitOnEnter } from './sendShortcut'
 import type { PermissionMode } from '../../types/settings'
-import { getSessionWorkspaceState } from '../../lib/sessionWorkspace'
 
 type GitInfo = SessionGitInfo
 
@@ -88,7 +87,7 @@ function insertComposerTokenAtRange(value: string, start: number, end: number, t
   }
 }
 
-export function ChatInput({ variant = 'default', compact = false }: ChatInputProps) {
+export function ChatInput({ variant = 'default', compact = false, sessionId }: ChatInputProps & { sessionId?: string }) {
   const t = useTranslation()
   const isMobileComposer = useMobileViewport() && !isDesktopRuntime()
   const [input, setInput] = useState('')
@@ -143,7 +142,7 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
     removeQueuedUserMessage,
     sendQueuedUserMessage,
   } = useChatStore()
-  const activeTabId = useTabStore((s) => s.activeTabId)
+  const activeTabId = sessionId ?? useTabStore((s) => s.activeTabId)
   const sessionState = useChatStore((s) => activeTabId ? s.sessions[activeTabId] : undefined)
   const chatState = sessionState?.chatState ?? 'idle'
   const slashCommands = sessionState?.slashCommands ?? []
@@ -188,12 +187,11 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
 
   const isMemberSession = !!memberInfo
   const isActive = chatState !== 'idle'
-  const workspaceState = getSessionWorkspaceState(activeSession)
-  const isWorkspaceMissing = workspaceState !== 'available'
+  const isWorkspaceMissing = activeSession?.workDirExists === false
   const hasWorkspaceReferences = !isMemberSession && workspaceReferences.length > 0
   const isHeroComposer = variant === 'hero' && !isMemberSession && !compact
   const resolvedWorkDir = activeSession?.workDir || gitInfo?.workDir || undefined
-  const showLaunchControls = !isMemberSession && messageCount === 0
+  const showLaunchControls = !isMemberSession && messageCount === 0 && !sessionId
   const useCompactControls = compact || isMobileComposer
   const iconOnlyAction = compact || isMobileComposer
   const activeLaunchWorkDir = showLaunchControls ? (launchWorkDir || resolvedWorkDir || '') : (resolvedWorkDir || '')
@@ -969,9 +967,7 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
     isHeroComposer
       ? t('empty.placeholder')
       : isWorkspaceMissing
-        ? workspaceState === 'worktree_removed'
-          ? t('chat.placeholderWorktreeRemoved')
-          : t('chat.placeholderMissing')
+        ? t('chat.placeholderMissing')
         : isMemberSession
           ? t('teams.memberPlaceholder')
           : t('chat.placeholder')
@@ -982,13 +978,13 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
   return (
     <div
       data-testid="chat-input-shell"
-      data-session-id={activeTabId ?? undefined}
+      data-session-id={sessionId ?? activeTabId ?? undefined}
       className={
         isHeroComposer
-          ? `bg-[var(--color-surface)] ${isMobileComposer ? 'px-4 pb-3' : 'px-8 pb-4'}`
+          ? `${isMobileComposer ? 'px-4 pb-3' : 'px-8 pb-4'}`
           : compact
-            ? `border-t border-[var(--color-border)]/70 bg-[var(--color-surface)] ${isMobileComposer ? 'px-3 pb-[calc(env(safe-area-inset-bottom)+10px)] pt-2' : 'px-3 py-3'}`
-            : `bg-[var(--color-surface)] ${isMobileComposer ? 'px-3 pb-[calc(env(safe-area-inset-bottom)+10px)] pt-2' : 'px-4 py-4'}`
+            ? `${isMobileComposer ? 'px-3 pb-[calc(env(safe-area-inset-bottom)+10px)] pt-2' : 'px-3 py-3'}`
+            : `${isMobileComposer ? 'px-3 pb-[calc(env(safe-area-inset-bottom)+10px)] pt-2' : 'px-4 py-4'}`
       }
     >
       <div
@@ -1072,7 +1068,7 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
             <div ref={slashMenuRef}>
               <LocalSlashCommandPanel
                 command={localSlashPanel}
-                sessionId={activeTabId ?? undefined}
+                sessionId={sessionId ?? activeTabId ?? undefined}
                 cwd={activeLaunchWorkDir || resolvedWorkDir}
                 commands={allSlashCommands}
                 onClose={() => setLocalSlashPanel(null)}
@@ -1271,54 +1267,62 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
           )}
 
           <div data-testid="chat-input-toolbar" className={isHeroComposer
-            ? 'flex items-center justify-between border-t border-[var(--color-border-separator)] pt-3'
-            : `mt-2 flex items-center justify-between border-t border-[var(--color-border-separator)] ${
-              useCompactControls ? `-mx-3 -mb-3 px-2.5 py-2 ${isMobileComposer ? 'gap-1' : 'gap-2'}` : '-mx-4 -mb-4 px-3 py-3'
-            }`}>
-            <div
-              data-testid="chat-input-toolbar-leading"
-              className={`flex min-w-0 items-center ${isMobileComposer ? 'shrink-0 gap-1' : 'gap-2'}`}
-            >
-              {!isMemberSession && (
-                <>
-                  <div ref={plusMenuRef} className="relative">
-                    <button
-                      onClick={() => setPlusMenuOpen((value) => !value)}
-                      aria-label="Open composer tools"
-                      className={`text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] ${isMobileComposer ? 'inline-flex h-11 w-11 items-center justify-center rounded-xl' : 'rounded-[var(--radius-md)] p-1.5'}`}
-                    >
-                      <span className="material-symbols-outlined text-[18px]">add</span>
-                    </button>
+                ? 'flex items-center justify-between border-t border-[var(--color-border-separator)] pt-3'
+                : `mt-2 flex items-center justify-between border-t border-[var(--color-border-separator)] ${
+                  useCompactControls ? '-mx-3 -mb-3 gap-2 px-2.5 py-2' : '-mx-4 -mb-4 px-3 py-3'
+                }`}>
+                <div className="flex min-w-0 items-center gap-2">
+                  {!isMemberSession && (
+                    <>
+                      <div ref={plusMenuRef} className="relative">
+                        <button
+                          onClick={() => setPlusMenuOpen((value) => !value)}
+                          aria-label="Open composer tools"
+                          className={`text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] ${isMobileComposer ? 'inline-flex h-11 w-11 items-center justify-center rounded-xl' : 'rounded-[var(--radius-md)] p-1.5'}`}
+                        >
+                          <span className="material-symbols-outlined text-[18px]">add</span>
+                        </button>
 
-                    {plusMenuOpen && (
-                      <div className={`absolute bottom-full left-0 z-50 mb-2 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] py-1 shadow-[var(--shadow-dropdown)] ${isMobileComposer ? 'w-[min(240px,calc(100vw-32px))]' : 'w-[240px]'}`}>
-                        <button
-                          onClick={openAttachmentPicker}
-                          className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-[var(--color-surface-hover)]"
-                        >
-                          <span className="material-symbols-outlined text-[18px] text-[var(--color-text-secondary)]">attach_file</span>
-                          <span className="text-sm text-[var(--color-text-primary)]">{addFilesLabel}</span>
-                        </button>
-                        <button
-                          onClick={insertSlashCommand}
-                          className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-[var(--color-surface-hover)]"
-                        >
-                          <span className="w-[24px] text-center text-[18px] font-bold text-[var(--color-text-secondary)]">/</span>
-                          <span className="text-sm text-[var(--color-text-primary)]">{slashCommandsLabel}</span>
-                        </button>
+                        {plusMenuOpen && (
+                          <div className={`absolute bottom-full left-0 z-50 mb-2 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] py-1 shadow-[var(--shadow-dropdown)] ${isMobileComposer ? 'w-[min(240px,calc(100vw-32px))]' : 'w-[240px]'}`}>
+                            <button
+                              onClick={openAttachmentPicker}
+                              className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-[var(--color-surface-hover)]"
+                            >
+                              <span className="material-symbols-outlined text-[18px] text-[var(--color-text-secondary)]">attach_file</span>
+                              <span className="text-sm text-[var(--color-text-primary)]">{addFilesLabel}</span>
+                            </button>
+                            <button
+                              onClick={insertSlashCommand}
+                              className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-[var(--color-surface-hover)]"
+                            >
+                              <span className="w-[24px] text-center text-[18px] font-bold text-[var(--color-text-secondary)]">/</span>
+                              <span className="text-sm text-[var(--color-text-primary)]">{slashCommandsLabel}</span>
+                            </button>
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </div>
 
-                  <PermissionModeSelector compact={useCompactControls} />
-                </>
-              )}
-            </div>
+                      {!showLaunchControls && resolvedWorkDir && (
+                        <ProjectContextChip
+                          workDir={resolvedWorkDir}
+                          repoName={gitInfo?.repoName || null}
+                          branch={gitInfo?.branch || null}
+                          sourceWorkDir={gitInfo?.worktree?.sourceWorkDir || null}
+                          isWorktree={!!gitInfo?.worktree?.enabled}
+                          worktreeSlug={gitInfo?.worktree?.slug || null}
+                          worktreePath={gitInfo?.worktree?.path || gitInfo?.worktree?.plannedPath || null}
+                          compact={useCompactControls}
+                          plain
+                        />
+                      )}
 
-            <div
-              data-testid="chat-input-toolbar-trailing"
-              className={`flex min-w-0 items-center ${isMobileComposer ? 'flex-1 justify-end gap-1' : 'gap-2'}`}
-            >
+                      <PermissionModeSelector compact={useCompactControls} />
+                    </>
+                  )}
+                </div>
+
+            <div className="flex min-w-0 items-center gap-2">
               {!isMemberSession && activeTabId && (
                 <ContextUsageIndicator
                   sessionId={activeTabId}
@@ -1331,13 +1335,7 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
                 />
               )}
               {!isMemberSession && activeTabId && (
-                <ModelSelector
-                  ref={modelSelectorRef}
-                  runtimeKey={activeTabId}
-                  disabled={isActive}
-                  compact={useCompactControls}
-                  fluid={isMobileComposer}
-                />
+                <ModelSelector ref={modelSelectorRef} runtimeKey={activeTabId} disabled={isActive} compact={useCompactControls} />
               )}
               <button
                 onClick={!isMemberSession && isActive ? () => stopGeneration(activeTabId!) : handleSubmit}
@@ -1383,37 +1381,10 @@ export function ChatInput({ variant = 'default', compact = false }: ChatInputPro
               />
             </div>
           )}
+
         </div>
 
         <input ref={fileInputRef} type="file" multiple className="hidden" onChange={handleFileSelect} />
-
-        {!isMemberSession && !embedLaunchControlsInHero && (
-          <div className={useCompactControls ? 'mt-2 flex min-w-0 px-1' : 'mt-3 px-1'}>
-            {messageCount > 0 ? (
-              <ProjectContextChip
-                workDir={resolvedWorkDir}
-                repoName={gitInfo?.repoName || null}
-                branch={gitInfo?.branch || null}
-                sourceWorkDir={gitInfo?.worktree?.sourceWorkDir || null}
-                isWorktree={!!gitInfo?.worktree?.enabled}
-                worktreeSlug={gitInfo?.worktree?.slug || null}
-                worktreePath={gitInfo?.worktree?.path || gitInfo?.worktree?.plannedPath || null}
-                compact={useCompactControls}
-              />
-            ) : (
-              <RepositoryLaunchControls
-                workDir={activeLaunchWorkDir}
-                onWorkDirChange={handleLaunchWorkDirChange}
-                branch={launchBranch}
-                onBranchChange={setLaunchBranch}
-                useWorktree={launchUseWorktree}
-                onUseWorktreeChange={setLaunchUseWorktree}
-                onLaunchReadyChange={setLaunchReady}
-                disabled={isActive || launchTransitioning}
-              />
-            )}
-          </div>
-        )}
       </div>
     </div>
   )

--- a/desktop/src/components/chat/SessionChat.tsx
+++ b/desktop/src/components/chat/SessionChat.tsx
@@ -1,0 +1,35 @@
+import { MessageList } from './MessageList'
+import { ChatInput } from './ChatInput'
+
+type Props = {
+  sessionId: string
+  compact?: boolean
+  isLoading?: boolean
+  error?: string | null
+}
+
+export function SessionChat({ sessionId, compact = false, isLoading, error }: Props) {
+  if (isLoading) {
+    return (
+      <div role="status" className="flex flex-1 items-center justify-center p-8 text-sm text-[var(--color-text-secondary)]">
+        <span className="material-symbols-outlined mr-2 animate-spin text-[18px]">progress_activity</span>
+        Loading...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="flex flex-1 items-center justify-center p-8 text-sm text-[var(--color-error)]">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <MessageList sessionId={sessionId} compact={compact} />
+      <ChatInput sessionId={sessionId} variant="default" compact={compact} />
+    </>
+  )
+}

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { Check, ChevronDown, Clock, Folder, FolderOpen, FolderPlus, GitBranch, LoaderCircle, MoreHorizontal, Pin, PinOff, RefreshCw, RotateCcw, SquarePen, X } from 'lucide-react'
 import { useSessionStore } from '../../stores/sessionStore'
+import { useSessionRuntimeStore } from '../../stores/sessionRuntimeStore'
 import { useUIStore } from '../../stores/uiStore'
 import { useTranslation, type TranslationKey } from '../../i18n'
 import { ConfirmDialog } from '../shared/ConfirmDialog'
@@ -14,7 +15,6 @@ import { desktopUiPreferencesApi, type SidebarProjectPreferences } from '../../a
 import { getDesktopHost } from '../../lib/desktopHost'
 import { publicAssetPath } from '../../lib/publicAsset'
 import { hasRunningBackgroundTasks } from '../../lib/backgroundTasks'
-import { getSessionWorkspaceState } from '../../lib/sessionWorkspace'
 
 const desktopHost = getDesktopHost()
 const isDesktopRuntime = desktopHost.isDesktop
@@ -47,17 +47,11 @@ type SidebarProps = {
   onRequestClose?: () => void
 }
 
-type SessionScrollAnchor = {
-  sessionId: string
-  topOffset: number
-}
-
 export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
   const t = useTranslation()
   const sessions = useSessionStore((s) => s.sessions)
   const isLoading = useSessionStore((s) => s.isLoading)
   const error = useSessionStore((s) => s.error)
-  const indexStatus = useSessionStore((s) => s.indexStatus)
   const fetchSessions = useSessionStore((s) => s.fetchSessions)
   const deleteSession = useSessionStore((s) => s.deleteSession)
   const deleteSessions = useSessionStore((s) => s.deleteSessions)
@@ -101,43 +95,7 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
   const [projectDropTarget, setProjectDropTarget] = useState<{ key: string; position: 'before' | 'after' } | null>(null)
   const suppressProjectClickRef = useRef<string | null>(null)
   const sidebarPreferenceRevisionRef = useRef(0)
-  const sessionScrollAreaRef = useRef<HTMLDivElement>(null)
-  const pendingSessionScrollAnchorRef = useRef<SessionScrollAnchor | null>(null)
   const refreshSessionsNow = useSessionListAutoRefresh(fetchSessions)
-
-  useEffect(() => useSessionStore.subscribe((nextState, previousState) => {
-    if (nextState.sessions === previousState.sessions) return
-
-    pendingSessionScrollAnchorRef.current = null
-    if (
-      nextState.indexStatus === previousState.indexStatus
-      || nextState.indexStatus?.mode !== 'on'
-      || nextState.indexStatus.state !== 'building'
-    ) {
-      return
-    }
-
-    const scrollArea = sessionScrollAreaRef.current
-    if (!scrollArea || scrollArea.scrollTop <= 0) return
-    pendingSessionScrollAnchorRef.current = readFirstVisibleSessionAnchor(scrollArea)
-  }), [])
-
-  useLayoutEffect(() => {
-    const anchor = pendingSessionScrollAnchorRef.current
-    pendingSessionScrollAnchorRef.current = null
-    if (!anchor) return
-
-    const scrollArea = sessionScrollAreaRef.current
-    if (!scrollArea || scrollArea.scrollTop <= 0) return
-    const row = findSessionRow(scrollArea, anchor.sessionId)
-    if (!row) return
-
-    const topOffset = row.getBoundingClientRect().top - scrollArea.getBoundingClientRect().top
-    const delta = topOffset - anchor.topOffset
-    if (Number.isFinite(delta) && delta !== 0) {
-      scrollArea.scrollTop += delta
-    }
-  }, [sessions])
 
   useEffect(() => {
     if (!contextMenu) return
@@ -173,17 +131,6 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
   }, [hiddenProjectKeys, orderedProjectGroups])
   const showInitialLoading = isLoading && sessions.length === 0
   const showRefreshLoading = showInitialLoading
-  const showIndexBuilding = indexStatus?.state === 'building' && sessions.length > 0
-  const showIndexDegraded = indexStatus?.state === 'degraded'
-  const indexAnnouncement = indexStatus
-    ? t(indexStatus.state === 'building'
-      ? 'sidebar.indexBuilding'
-      : indexStatus.state === 'ready'
-        ? 'sidebar.indexReady'
-        : indexStatus.state === 'degraded'
-          ? 'sidebar.indexDegraded'
-          : 'sidebar.indexOff')
-    : ''
   const filteredSessionIds = useMemo(() => filteredSessions.map((session) => session.id), [filteredSessions])
   const selectedCount = selectedSessionIds.size
   const sessionsById = useMemo(
@@ -334,10 +281,15 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
 
   const createSessionForWorkDir = useCallback(async (workDir?: string) => {
     try {
+      const prevTabId = useTabStore.getState().activeTabId
       const sessionId = await useSessionStore.getState().createSession(workDir)
       restoreHiddenProjectForWorkDir(workDir)
       useTabStore.getState().openTab(sessionId, t('sidebar.newSession'))
       useChatStore.getState().connectToSession(sessionId)
+      const sel = prevTabId
+        ? useSessionRuntimeStore.getState().selections[prevTabId]
+        : Object.values(useSessionRuntimeStore.getState().selections)[0]
+      if (sel) useSessionRuntimeStore.getState().setSelection(sessionId, sel)
       closeMobileDrawer()
     } catch (error) {
       addToast({
@@ -742,21 +694,19 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
             {t('sidebar.scheduled')}
           </NavItem>
         )}
-        {!isMobile && (
-          <NavItem
-            active={activeTabId === MARKET_TAB_ID}
-            collapsed={!expanded}
-            label={t('sidebar.market')}
-            touchFriendly={isMobile}
-            onClick={() => {
-              useTabStore.getState().openTab(MARKET_TAB_ID, t('sidebar.market'), 'market')
-              closeMobileDrawer()
-            }}
-            icon={<StorefrontIcon />}
-          >
-            {t('sidebar.market')}
-          </NavItem>
-        )}
+        <NavItem
+          active={activeTabId === MARKET_TAB_ID}
+          collapsed={!expanded}
+          label={t('sidebar.market')}
+          touchFriendly={isMobile}
+          onClick={() => {
+            useTabStore.getState().openTab(MARKET_TAB_ID, t('sidebar.market'), 'market')
+            closeMobileDrawer()
+          }}
+          icon={<StorefrontIcon />}
+        >
+          {t('sidebar.market')}
+        </NavItem>
       </div>
 
       {expanded ? (
@@ -855,35 +805,7 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
                 </div>
               </div>
             )}
-            <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-              {indexAnnouncement}
-            </div>
-            {showIndexBuilding && (
-              <div
-                data-testid="sidebar-index-progress"
-                aria-hidden="true"
-                className="mx-4 mb-1 flex-none text-[11px] leading-5 text-[var(--color-text-tertiary)]"
-              >
-                {t('sidebar.indexBuildingProgress', {
-                  indexed: indexStatus.indexed,
-                  discovered: indexStatus.discovered,
-                })}
-              </div>
-            )}
-            {showIndexDegraded && (
-              <div
-                data-testid="sidebar-index-degraded"
-                aria-hidden="true"
-                className="mx-4 mb-1 flex-none text-[11px] leading-5 text-[var(--color-text-tertiary)]"
-              >
-                {t('sidebar.indexDegraded')}
-              </div>
-            )}
-            <div
-              ref={sessionScrollAreaRef}
-              data-testid="sidebar-session-scroll-area"
-              className="sidebar-scroll-area min-h-0 flex-1 overflow-y-auto px-3 pb-20"
-            >
+            <div className="sidebar-scroll-area min-h-0 flex-1 overflow-y-auto px-3 pb-20">
               {error && (
                 <div className="mx-1 mt-2 rounded-[var(--radius-md)] border border-[var(--color-error)]/20 bg-[var(--color-error)]/5 px-3 py-2">
                   <div className="text-xs font-medium text-[var(--color-error)]">{t('sidebar.sessionListFailed')}</div>
@@ -919,7 +841,7 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
                 const sessionsExpanded = expandedProjectKeys.has(project.key)
                 const visibleItems = projectCollapsed
                   ? []
-                  : getVisibleProjectSessions(project.sessions, sessionsExpanded, activeTabId)
+                  : getVisibleProjectSessions(project.sessions.filter(s => !(s as any).side), sessionsExpanded, activeTabId)
                 const hiddenCount = project.sessions.length - visibleItems.length
                 const groupIds = project.sessions.map((session) => session.id)
                 const groupSelectedCount = groupIds.filter((id) => selectedSessionIds.has(id)).length
@@ -1038,11 +960,7 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
                           data-testid={`sidebar-project-session-list-${domSafeProjectKey(project.key)}`}
                         >
                           {visibleItems.map((session) => (
-                            <div
-                              key={session.id}
-                              data-sidebar-session-id={session.id}
-                              className="relative mb-0.5 last:mb-0"
-                            >
+                            <div key={session.id} className="relative mb-0.5 last:mb-0">
                               {renamingId === session.id ? (
                                 <input
                                   autoFocus
@@ -1098,7 +1016,7 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
                                       </span>
                                     ) : null}
                                     <span className="min-w-0 flex-1 truncate font-medium tracking-normal">{session.title || 'Untitled'}</span>
-                                    {getSessionWorkspaceState(session) === 'missing' && (
+                                    {!session.workDirExists && (
                                       <span
                                         className="flex-shrink-0 text-[10px] text-[var(--color-warning)]"
                                         title={session.workDir ?? ''}
@@ -1145,6 +1063,11 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
         </>
       ) : (
         <div className="flex-1" aria-hidden="true" />
+      )}
+
+      {!isMobile && expanded && (
+        <div className="pb-12">
+        </div>
       )}
 
       {!isMobile && (
@@ -1367,30 +1290,6 @@ function useSessionListAutoRefresh(fetchSessions: () => Promise<void>): () => Pr
 
 function isDocumentVisible(): boolean {
   return typeof document === 'undefined' || document.visibilityState !== 'hidden'
-}
-
-function readFirstVisibleSessionAnchor(scrollArea: HTMLElement): SessionScrollAnchor | null {
-  const scrollRect = scrollArea.getBoundingClientRect()
-  const rows = scrollArea.querySelectorAll<HTMLElement>('[data-sidebar-session-id]')
-  for (const row of rows) {
-    const rowRect = row.getBoundingClientRect()
-    if (rowRect.bottom <= scrollRect.top || rowRect.top >= scrollRect.bottom) continue
-    const sessionId = row.dataset.sidebarSessionId
-    if (!sessionId) continue
-    return {
-      sessionId,
-      topOffset: rowRect.top - scrollRect.top,
-    }
-  }
-  return null
-}
-
-function findSessionRow(scrollArea: HTMLElement, sessionId: string): HTMLElement | null {
-  const rows = scrollArea.querySelectorAll<HTMLElement>('[data-sidebar-session-id]')
-  for (const row of rows) {
-    if (row.dataset.sidebarSessionId === sessionId) return row
-  }
-  return null
 }
 
 function ProjectHeaderActions({

--- a/desktop/src/components/side/SideSessionPanel.tsx
+++ b/desktop/src/components/side/SideSessionPanel.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from 'react'
+import { useUIStore } from '../../stores/uiStore'
+import { useTabStore } from '../../stores/tabStore'
+import { useSessionStore } from '../../stores/sessionStore'
+import { useTranslation } from '../../i18n'
+import { SessionChat } from '../chat/SessionChat'
+
+export function SideSessionPanel() {
+  const t = useTranslation()
+  const activeTabId = useTabStore((s) => s.activeTabId)
+  const sideSessions = useUIStore((s) => s.sideSessions)
+  const clearSideSession = useUIStore((s) => s.clearSideSession)
+  const deleteSession = useSessionStore((s) => s.deleteSession)
+  const [width, setWidth] = useState(() => {
+    const chatWidth = window.innerWidth - 340  // 减左侧列表宽度
+    return Math.min(Math.max(Math.floor(chatWidth * 0.4), 280), chatWidth * 0.5)
+  })
+
+  const sideSessionId = activeTabId ? sideSessions[activeTabId] : undefined
+
+  // 拖拽分隔线
+  const dragRef = useRef(false)
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(480)
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    dragRef.current = true
+    startXRef.current = e.clientX
+    startWidthRef.current = width
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+  }, [width])
+
+  const onMouseMove = useCallback((e: MouseEvent) => {
+    if (!dragRef.current) return
+    const delta = startXRef.current - e.clientX
+    const next = Math.min(Math.max(startWidthRef.current + delta, 280), window.innerWidth * 0.5)
+    setWidth(next)
+  }, [])
+
+  const onMouseUp = useCallback(() => {
+    dragRef.current = false
+    document.removeEventListener('mousemove', onMouseMove)
+    document.removeEventListener('mouseup', onMouseUp)
+  }, [onMouseMove])
+
+  const wrapperClass = "relative flex flex-col flex-shrink-0 border-l border-[var(--color-border)] min-w-[280px] max-w-[50vw] bg-[var(--color-background)]"
+
+  if (!sideSessionId) return null
+
+  return (
+    <div className={wrapperClass} style={{ width }}>
+      {/* 可拖拽分割线 */}
+      <div
+        onMouseDown={onMouseDown}
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-[var(--color-accent)]/20 z-10"
+        style={{ marginLeft: -2 }}
+      />
+
+      <div className="self-start group inline-flex items-center gap-2 shrink-0 m-2 px-3 py-1.5 rounded-lg bg-[var(--color-surface-container-low)]">
+        <span className="text-xs font-medium text-[var(--color-text-tertiary)] group-hover:text-[var(--color-text-primary)]">{t('sideChat.label')}</span>
+        <button
+          onClick={async () => { try { await deleteSession(sideSessionId) } catch {}; clearSideSession(activeTabId!) }}
+          className="rounded p-0.5 text-[var(--color-text-tertiary)] group-hover:bg-[var(--color-surface-hover)] group-hover:text-[var(--color-text-primary)]"
+        >✕</button>
+      </div>
+      <div className="flex flex-col flex-1 min-h-0 bg-[var(--color-background)]">
+        <SessionChat sessionId={sideSessionId} />
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/pages/ActiveSession.tsx
+++ b/desktop/src/pages/ActiveSession.tsx
@@ -11,7 +11,9 @@ import {
   type TabType,
 } from '../stores/tabStore'
 import { useSessionStore } from '../stores/sessionStore'
+import { useSessionRuntimeStore } from '../stores/sessionRuntimeStore'
 import { useChatStore } from '../stores/chatStore'
+import { useUIStore } from '../stores/uiStore'
 import { useCLITaskStore } from '../stores/cliTaskStore'
 import { useTeamStore } from '../stores/teamStore'
 import { useWorkspacePanelStore } from '../stores/workspacePanelStore'
@@ -24,6 +26,7 @@ import {
 import { useTranslation } from '../i18n'
 import { MessageList } from '../components/chat/MessageList'
 import { ChatInput } from '../components/chat/ChatInput'
+import { SideSessionPanel } from '../components/side/SideSessionPanel'
 import { ComputerUsePermissionModal } from '../components/chat/ComputerUsePermissionModal'
 import { WorkbenchPanel } from '../components/workbench/WorkbenchPanel'
 import { SessionActivityPanel } from '../components/activity/SessionActivityPanel'
@@ -41,7 +44,6 @@ import {
   hasRunningBackgroundTasks as hasAnyRunningBackgroundTasks,
 } from '../lib/backgroundTasks'
 import { useActivityPanelStore } from '../stores/activityPanelStore'
-import { getSessionBrowsablePath, getSessionWorkspaceState } from '../lib/sessionWorkspace'
 
 const TASK_POLL_INTERVAL_MS = 1000
 const WORKSPACE_RESIZE_STEP = 32
@@ -71,7 +73,9 @@ function getTokenUsageTotal(usage: TokenUsage): number {
 }
 
 function getSessionTerminalCwd(session: SessionListItem | undefined) {
-  return getSessionBrowsablePath(session)
+  if (!session) return undefined
+  if (session.workDir && session.workDirExists !== false) return session.workDir
+  return session.projectPath || undefined
 }
 
 function ActiveGoalStrip({
@@ -325,7 +329,8 @@ export function ActiveSession() {
       ? state.isPanelOpen(activeTabId)
       : false,
   )
-  const showRightPanel = showWorkbench
+  const sideSessionId = useUIStore((s) => activeTabId ? s.sideSessions[activeTabId] : undefined)
+  const showRightPanel = showWorkbench || !!sideSessionId
   const rightPanelWidth = useWorkspacePanelStore((state) => state.width)
   const showTerminalPanel = useTerminalPanelStore((state) =>
     activeTabId && isSessionTabState(activeTabId, activeTabType) && !isMemberSession && !isMobileLayout
@@ -507,12 +512,112 @@ export function ActiveSession() {
 
   if (!activeTabId) return null
 
+  function renderSessionHeader() {
+    return (
+      <>
+      {!isMemberSession && !isMobileLayout && (
+      <div
+      className={
+      showWorkbench
+      ? 'flex w-full items-center border-b border-[var(--color-border)]/70 px-4 py-3'
+      : 'w-full border-b border-outline-variant/10 px-4 py-3'
+      }
+      >
+      <div className={showRightPanel ? 'min-w-0 flex-1' : 'mx-auto w-full max-w-[860px] min-w-0'}>
+      <div className="flex min-w-0 items-center gap-3">
+      <h1
+      className={
+      showRightPanel
+      ? 'min-w-0 flex-1 truncate text-[15px] font-bold font-headline leading-tight text-on-surface'
+      : 'min-w-0 flex-1 text-lg font-bold font-headline text-on-surface leading-tight'
+      }
+      >
+      {session?.title || t('session.untitled')}
+      </h1>
+      {!isMemberSession && (
+      <button
+      onClick={() => {
+      if (!activeTabId) return
+      const store = useUIStore.getState()
+      store.setSideSession(activeTabId, '')
+      const { createSession } = useSessionStore.getState()
+      const mainSession = useSessionStore.getState().sessions.find(s => s.id === activeTabId)
+      createSession(mainSession?.workDir ?? undefined)
+      .then((sessionId) => {
+      store.setSideSession(activeTabId, sessionId)
+      useSessionStore.setState({ activeSessionId: activeTabId })
+      useChatStore.getState().connectToSession(sessionId)
+      const sel = useSessionRuntimeStore.getState().selections[activeTabId]
+      if (sel) useSessionRuntimeStore.getState().setSelection(sessionId, sel)
+      })
+      .catch(() => store.clearSideSession(activeTabId))
+      }}
+      disabled={!!sideSessionId}
+      className="ml-auto cursor-pointer rounded p-1.5 text-xs text-[var(--color-text-tertiary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-30 disabled:cursor-default"
+      title="Open side chat"
+      ><span className="material-symbols-outlined text-[16px]">vertical_split</span></button>
+      )}
+      </div>
+      <div
+      className={
+      showRightPanel
+      ? 'mt-1 flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap text-[10px] font-medium text-outline'
+      : 'flex items-center gap-2 text-[10px] text-outline font-medium mt-1'
+      }
+      >
+      {isActive && (
+      <span className="flex shrink-0 items-center gap-1">
+      <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] animate-pulse-dot" />
+      {t('session.active')}
+      </span>
+      )}
+      {totalTokens > 0 && (
+      <>
+      <span className="text-[var(--color-outline)]">·</span>
+      <span title={t('common.tokens', { count: totalTokens.toLocaleString() })}>
+      {t('common.tokens', { count: formatTokenCount(totalTokens) })}
+      </span>
+      </>
+      )}
+      {lastUpdated && (
+      <>
+      <span className="shrink-0 text-[var(--color-outline)]">·</span>
+      <span className="truncate">{t('session.lastUpdated', { time: lastUpdated })}</span>
+      </>
+      )}
+      {!showRightPanel && visibleMessageCount > 0 && (
+      <>
+      <span className="text-[var(--color-outline)]">·</span>
+      <span>{t('session.messages', { count: visibleMessageCount })}</span>
+      </>
+      )}
+      </div>
+      {session?.workDirExists === false && (
+      <div className="mt-2 inline-flex max-w-full items-center gap-2 rounded-lg border border-[var(--color-error)]/20 bg-[var(--color-error)]/8 px-3 py-1.5 text-[11px] text-[var(--color-error)]">
+      <span className="material-symbols-outlined text-[14px]">warning</span>
+      <span className="truncate">
+      {t('session.workspaceUnavailable', { dir: session.workDir || 'directory no longer exists' })}
+      </span>
+      </div>
+      )}
+      <ActiveGoalStrip
+      goal={activeGoal}
+      isRunning={isActive}
+      compact={showRightPanel}
+      />
+      </div>
+      </div>
+      )}
+      </>
+    )
+  }
+
   return (
     <div className="flex-1 flex relative overflow-hidden bg-background text-on-surface">
       <div data-testid="active-session-content-row" className="flex min-h-0 min-w-0 flex-1">
         <div
           data-testid="active-session-chat-column"
-          className={`relative flex min-h-0 min-w-0 flex-col overflow-hidden ${showRightPanel ? CHAT_COLUMN_WITH_WORKSPACE_CLASS : isMobileLayout ? 'flex-1' : 'min-w-[360px] flex-1'}`}
+          className={`relative flex min-h-0 min-w-0 flex-col overflow-hidden ${showWorkbench ? CHAT_COLUMN_WITH_WORKSPACE_CLASS : isMobileLayout ? 'flex-1' : 'min-w-[360px] flex-1'}`}
         >
           {isMemberSession && (
             <div className="shrink-0 border-b border-[var(--color-border)] bg-[var(--color-surface-container)]">
@@ -560,13 +665,14 @@ export function ActiveSession() {
           )}
 
           {isEmpty ? (
-            <div
-              data-testid="empty-session-hero"
-              className={[
-                'flex min-h-0 flex-1 flex-col items-center justify-center overflow-hidden px-8 pt-8',
-                compactEmptyHero ? 'pb-6' : 'pb-32',
-              ].join(' ')}
-            >
+            <>
+              <div
+                data-testid="empty-session-hero"
+                className={[
+                  'flex min-h-0 flex-1 flex-col items-center justify-center overflow-hidden px-8 pt-8',
+                  compactEmptyHero ? 'pb-6' : 'pb-32',
+                ].join(' ')}
+              >
               <div className="flex max-w-md flex-col items-center text-center">
                 {isMemberSession ? (
                   <>
@@ -594,86 +700,14 @@ export function ActiveSession() {
                 )}
               </div>
             </div>
-          ) : (
+            <ChatInput
+              variant="hero"
+              compact={showWorkbench}
+            />
+          </>
+        ) : (
             <>
-              {!isMemberSession && !isMobileLayout && (
-                <div
-                  className={
-                    showRightPanel
-                      ? 'flex w-full items-center border-b border-[var(--color-border)]/70 px-4 py-3'
-                      : 'w-full border-b border-outline-variant/10 px-4 py-3'
-                  }
-                >
-                  <div className={showRightPanel ? 'min-w-0 flex-1' : 'mx-auto w-full max-w-[860px] min-w-0'}>
-                    <div className="flex min-w-0 items-center gap-3">
-                      <h1
-                        className={
-                          showRightPanel
-                            ? 'min-w-0 flex-1 truncate text-[15px] font-bold font-headline leading-tight text-on-surface'
-                            : 'min-w-0 flex-1 text-lg font-bold font-headline text-on-surface leading-tight'
-                        }
-                      >
-                        {session?.title || t('session.untitled')}
-                      </h1>
-                    </div>
-                    <div
-                      className={
-                        showRightPanel
-                          ? 'mt-1 flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap text-[10px] font-medium text-outline'
-                          : 'flex items-center gap-2 text-[10px] text-outline font-medium mt-1'
-                      }
-                    >
-                      {isActive && (
-                        <span className="flex shrink-0 items-center gap-1">
-                          <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] animate-pulse-dot" />
-                          {t('session.active')}
-                        </span>
-                      )}
-                      {totalTokens > 0 && (
-                        <>
-                          <span className="text-[var(--color-outline)]">·</span>
-                          <span title={t('common.tokens', { count: totalTokens.toLocaleString() })}>
-                            {t('common.tokens', { count: formatTokenCount(totalTokens) })}
-                          </span>
-                        </>
-                      )}
-                      {lastUpdated && (
-                        <>
-                          <span className="shrink-0 text-[var(--color-outline)]">·</span>
-                          <span className="truncate">{t('session.lastUpdated', { time: lastUpdated })}</span>
-                        </>
-                      )}
-                      {!showRightPanel && visibleMessageCount > 0 && (
-                        <>
-                          <span className="text-[var(--color-outline)]">·</span>
-                          <span>{t('session.messages', { count: visibleMessageCount })}</span>
-                        </>
-                      )}
-                    </div>
-                    {session && getSessionWorkspaceState(session) !== 'available' && (
-                      <div className={`mt-2 inline-flex max-w-full items-center gap-2 rounded-lg border px-3 py-1.5 text-[11px] ${
-                        getSessionWorkspaceState(session) === 'worktree_removed'
-                          ? 'border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--color-text-secondary)]'
-                          : 'border-[var(--color-error)]/20 bg-[var(--color-error)]/8 text-[var(--color-error)]'
-                      }`}>
-                        <span className="material-symbols-outlined text-[14px]">
-                          {getSessionWorkspaceState(session) === 'worktree_removed' ? 'history' : 'warning'}
-                        </span>
-                        <span className="truncate">
-                          {getSessionWorkspaceState(session) === 'worktree_removed'
-                            ? t('session.worktreeRemoved', { dir: session.projectRoot || '' })
-                            : t('session.workspaceUnavailable', { dir: session.workDir || 'directory no longer exists' })}
-                        </span>
-                      </div>
-                    )}
-                    <ActiveGoalStrip
-                      goal={activeGoal}
-                      isRunning={isActive}
-                      compact={showRightPanel}
-                    />
-                  </div>
-                </div>
-              )}
+              {!sideSessionId && renderSessionHeader()}
 
               {isHistoryLoading ? (
                 <div role="status" className="flex flex-1 items-center justify-center p-8 text-sm text-[var(--color-text-secondary)]">
@@ -685,7 +719,17 @@ export function ActiveSession() {
                   {historyError}
                 </div>
               ) : (
-                <MessageList compact={showRightPanel} mobileLayout={isMobileLayout} />
+                <div className="flex flex-1 min-h-0">
+                  <div className="flex flex-col flex-1 min-w-0 bg-[var(--color-background)]">
+                        {sideSessionId && renderSessionHeader()}
+                    <MessageList compact={showRightPanel} />
+                    <ChatInput
+                      variant={isEmpty && !isMemberSession && !showRightPanel ? 'hero' : 'default'}
+                      compact={showWorkbench}
+                    />
+                  </div>
+                  {sideSessionId && <SideSessionPanel />}
+                </div>
               )}
             </>
           )}
@@ -704,10 +748,6 @@ export function ActiveSession() {
             />
           ) : null}
 
-          <ChatInput
-            variant={isEmpty && !isMemberSession && !showRightPanel ? 'hero' : 'default'}
-            compact={showRightPanel}
-          />
 
           {terminalPanelRuntimeId && activeTabId ? (
             <div

--- a/desktop/src/stores/sessionStore.ts
+++ b/desktop/src/stores/sessionStore.ts
@@ -8,6 +8,7 @@ import {
 import { useSessionRuntimeStore } from './sessionRuntimeStore'
 import { useSettingsStore } from './settingsStore'
 import { useTabStore } from './tabStore'
+import { useUIStore } from './uiStore'
 import type { LocalIndexStatus, SessionListItem } from '../types/session'
 import type { PermissionMode } from '../types/settings'
 import { isPlaceholderSessionTitle } from '../lib/sessionTitle'
@@ -85,6 +86,11 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           state.sessions,
         )
         syncedSessions = sessions
+        // 补打 side 标记：侧会话不出现在左列表
+        const sideIds = new Set(Object.values(useUIStore.getState().sideSessions))
+        if (sideIds.size > 0) {
+          sessions.forEach(s => { if (sideIds.has(s.id)) (s as any).side = true })
+        }
         return {
           sessions,
           indexStatus,

--- a/desktop/src/stores/uiStore.ts
+++ b/desktop/src/stores/uiStore.ts
@@ -27,7 +27,7 @@ function getStoredTheme(): ThemeMode {
     const stored = localStorage.getItem(THEME_STORAGE_KEY)
     if (isThemeMode(stored)) return stored
   } catch { /* localStorage unavailable */ }
-  return 'white'
+  return 'light'
 }
 
 function isSettingsTab(value: unknown): value is SettingsTab {
@@ -46,6 +46,50 @@ export function applyTheme(theme: ThemeMode) {
   if (typeof document === 'undefined') return
   document.documentElement.setAttribute('data-theme', theme)
   document.documentElement.style.colorScheme = theme === 'dark' ? 'dark' : 'light'
+}
+
+const PRESET_STORAGE_KEY = 'cc-haha-theme-preset'
+
+function getStoredPreset(): string {
+  if (typeof window === 'undefined') return ''
+  try {
+    return localStorage.getItem(PRESET_STORAGE_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function setStoredPreset(preset: string) {
+  if (typeof window === 'undefined') return
+  try {
+    if (preset) localStorage.setItem(PRESET_STORAGE_KEY, preset)
+    else localStorage.removeItem(PRESET_STORAGE_KEY)
+  } catch { /* quota exceeded, ignore */ }
+}
+
+let _presetLink: HTMLLinkElement | null = null
+
+export function applyPreset(preset: string) {
+  if (typeof document === 'undefined') return
+  document.documentElement.setAttribute('data-theme-preset', preset)
+  setStoredPreset(preset)
+  // Remove old preset CSS link
+  if (_presetLink) {
+    _presetLink.remove()
+    _presetLink = null
+  }
+  // Inject new preset CSS
+  if (preset) {
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = `./themes/${preset}.css`
+    document.head.appendChild(link)
+    _presetLink = link
+  }
+}
+
+export function initializePreset() {
+  applyPreset(getStoredPreset())
 }
 
 export function initializeTheme() {
@@ -87,12 +131,15 @@ type UIStore = {
   pendingMemoryPath: string | null
   activeModal: string | null
   toasts: Toast[]
+  sideSessions: Record<string, string>
 
   setTheme: (theme: ThemeMode) => void
   toggleTheme: () => void
   toggleSidebar: () => void
   setSidebarOpen: (open: boolean) => void
   setActiveView: (view: ActiveView) => void
+  setSideSession: (tabId: string, sessionId: string) => void
+  clearSideSession: (tabId: string) => void
   setActiveSettingsTab: (tab: SettingsTab) => void
   setPendingSettingsTab: (tab: SettingsTab | null) => void
   setPendingMemoryPath: (path: string | null) => void
@@ -113,6 +160,7 @@ export const useUIStore = create<UIStore>((set) => ({
   pendingMemoryPath: null,
   activeModal: null,
   toasts: [],
+  sideSessions: {} as Record<string, string>,
 
   setTheme: (theme) => {
     applyTheme(theme)
@@ -133,6 +181,13 @@ export const useUIStore = create<UIStore>((set) => ({
   toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
   setActiveView: (view) => set({ activeView: view }),
+  setSideSession: (tabId, sessionId) => set((s) => ({
+    sideSessions: { ...s.sideSessions, [tabId]: sessionId }
+  })),
+  clearSideSession: (tabId) => set((s) => {
+    const { [tabId]: _, ...rest } = s.sideSessions
+    return { sideSessions: rest }
+  }),
   setActiveSettingsTab: (tab) => {
     try { localStorage.setItem(ACTIVE_SETTINGS_TAB_STORAGE_KEY, tab) } catch { /* noop */ }
     set({ activeSettingsTab: tab })

--- a/desktop/src/stores/workspacePanelStore.ts
+++ b/desktop/src/stores/workspacePanelStore.ts
@@ -7,7 +7,7 @@ import {
   type WorkspaceTreeResult,
 } from '../api/sessions'
 
-export const WORKSPACE_PANEL_DEFAULT_WIDTH = 860
+export const WORKSPACE_PANEL_DEFAULT_WIDTH = 450
 export const WORKSPACE_PANEL_MIN_WIDTH = 420
 export const WORKSPACE_PANEL_MAX_WIDTH = 1120
 

--- a/desktop/src/types/session.ts
+++ b/desktop/src/types/session.ts
@@ -32,6 +32,7 @@ export type SessionListItem = {
   runtimeProviderId?: string | null
   runtimeModelId?: string
   effortLevel?: ReasoningEffortLevel
+  side?: boolean
 }
 
 export type SessionWorkspaceState = 'available' | 'worktree_removed' | 'missing'


### PR DESCRIPTION
## What

Adds a **side session panel** for parallel chat alongside the active tab. Also fixes new sessions defaulting to a hardcoded model.

### Side Session
- **SideSessionPanel** — draggable panel (280px-50vw) with full ChatInput + MessageList pipeline
- **SessionChat** — extracted MessageList + ChatInput shared by main and side
- **vertical_split** button in session header to toggle side panel
- **uiStore.sideSessions** — ephemeral per-tab memory map
- **sessionStore** — side flag, Sidebar filters side sessions
- **ChatInput** — sessionId prop + launchControls skip for side
- **workspacePanelStore** — 450px default for side-panel co-layout
- **Compact fix** — only workbench triggers compact, not side panel
- **HERO fix** — empty sessions now render ChatInput

### Model Inheritance
- New sessions inherit model/provider from last active session
- Falls back to any existing selection on first-start

### Files: 9 changed