### PR TITLE
feat: theme UX improvements + 16 warm-toned presets

### DIFF
--- a/desktop/src/pages/Settings.tsx
+++ b/desktop/src/pages/Settings.tsx
@@ -50,6 +50,7 @@ import { TraceList } from './TraceList'
 import { ActivitySettings } from './ActivitySettings'
 import { MemorySettings } from './MemorySettings'
 import { useUIStore } from '../stores/uiStore'
+import { applyPreset } from '../stores/uiStore'
 import { ClaudeOfficialLogin } from '../components/settings/ClaudeOfficialLogin'
 import { ChatGPTOfficialLogin } from '../components/settings/ChatGPTOfficialLogin'
 import { GrokOfficialLogin } from '../components/settings/GrokOfficialLogin'
@@ -2225,6 +2226,135 @@ export function GeneralSettings() {
     { value: 'dark', label: t('settings.general.appearance.dark') },
   ]
 
+  // Preset theme overlay
+  const DEFAULT_PRESETS: Array<{ value: string; label: string }> = [
+    { value: '', label: 'None' },
+    { value: 'cyberpunk-dark', label: 'Cyberpunk·霓虹绿' },
+    { value: 'ember-dark', label: 'Ember·熔炉暖' },
+    { value: 'midnight-dark', label: 'Midnight·暗紫' },
+    { value: 'mono-dark', label: 'Mono·极简灰' },
+    { value: 'nous-dark', label: 'Nous·经典蓝' },
+    { value: 'slate-dark', label: 'Slate·石板灰' },
+    { value: 'monochromator-light-amber-dark', label: 'Monochromator Amber' },
+    { value: 'monochromator-light-amethyst-dark', label: 'Monochromator Amethyst' },
+    { value: 'monochromator-light-aquamarine-dark', label: 'Monochromator Aquamarine' },
+    { value: 'monochromator-light-dark', label: 'Monochromator Default' },
+    { value: 'monochromator-light-emerald-dark', label: 'Monochromator Emerald' },
+    { value: 'monochromator-light-plain-dark', label: 'Monochromator Plain' },
+    { value: 'monochromator-light-ruby-dark', label: 'Monochromator Ruby' },
+    { value: 'monochromator-light-sulfur-dark', label: 'Monochromator Sulfur' },
+    { value: 'catppuccin-frappé-dark', label: 'Catppuccin Frappé' },
+    { value: 'catppuccin-latte-dark', label: 'Catppuccin Latte' },
+    { value: 'catppuccin-macchiato-dark', label: 'Catppuccin Macchiato' },
+    { value: 'catppuccin-mocha-dark', label: 'Catppuccin Mocha' },
+    { value: 'jetbrains-darcula-dark', label: 'JetBrains Darcula' },
+    { value: 'fullstacksjs-dark', label: 'FullstacksJS Dark' },
+    { value: 's-kill-dark', label: 'FullstacksJS Legacy' },
+    { value: 'fullstacksjs-dark', label: 'FullstacksJS Main' },
+    { value: 'fullstacksjs-dark', label: 'FullstacksJS Warm' },
+    { value: 'ember-dark-dark', label: 'Hearth Ember Dark' },
+    { value: 'ember-light-dark', label: 'Hearth Ember Light' },
+    { value: 'moss-dark-dark', label: 'Hearth Moss Dark' },
+    { value: 'moss-light-dark', label: 'Hearth Moss Light' },
+    { value: 'gruvbox-dark-hard-dark', label: 'Gruvbox Dark Hard' },
+    { value: 'gruvbox-dark-medium-dark', label: 'Gruvbox Dark Medium' },
+    { value: 'gruvbox-dark-soft-dark', label: 'Gruvbox Dark Soft' },
+    { value: 'gruvbox-light-hard-dark', label: 'Gruvbox Light Hard' },
+    { value: 'gruvbox-light-medium-dark', label: 'Gruvbox Light Medium' },
+    { value: 'gruvbox-light-soft-dark', label: 'Gruvbox Light Soft' },
+    { value: 'monokai-classic-dark', label: 'Monokai Classic' },
+    { value: 'monokai-pro-(filter-machine)-dark', label: 'Monokai Pro Machine' },
+    { value: 'monokai-pro-(filter-octagon)-dark', label: 'Monokai Pro Octagon' },
+    { value: 'monokai-pro-(filter-ristretto)-dark', label: 'Monokai Pro Ristretto' },
+    { value: 'monokai-pro-(filter-spectrum)-dark', label: 'Monokai Pro Spectrum' },
+    { value: 'monokai-pro-dark', label: 'Monokai Pro' },
+    { value: 'monokai-pro-light-dark', label: 'Monokai Pro Light' },
+    { value: 'deliriumtheme-aquarelle-cymbidium-dark', label: 'Delirium Cymbidium' },
+    { value: 'deliriumtheme-aquarelle-hydrangea-dark', label: 'Delirium Hydrangea' },
+    { value: 'deliriumtheme-aquarelle-lilac-dark', label: 'Delirium Lilac' },
+    { value: 'deliriumtheme-aquarelle-pumpkin-dark', label: 'Delirium Pumpkin' },
+    { value: 'deliriumtheme-aquarelle-swamp-dark', label: 'Delirium Swamp' },
+    { value: 'deliriumtheme-everforest-dark', label: 'Everforest' },
+    { value: 'deliriumtheme-everforest-dark-dark', label: 'Everforest Dark' },
+    { value: 'deliriumtheme-everforest-light-dark', label: 'Everforest Light' },
+    { value: 'deliriumtheme-everforest-lilac-dark', label: 'Everforest Lilac' },
+    { value: 'deliriumtheme-jetbrain-dark-dark', label: 'JetBrain Dark' },
+    { value: 'deliriumtheme-jetbrain-light-dark', label: 'JetBrain Light' },
+    { value: 'deliriumtheme-pumpkin-dark-dark', label: 'Pumpkin Dark' },
+    { value: 'deliriumtheme-pumpkin-dark', label: 'Pumpkin' },
+    { value: 'rosé-pine-dark', label: 'Rosé Pine' },
+    { value: 'rosé-pine-dawn-dark', label: 'Rosé Pine Dawn' },
+    { value: 'rosé-pine-moon-dark', label: 'Rosé Pine Moon' },
+    { value: 'pittaya-theme-dark', label: 'Pittaya Dark' },
+    { value: 'pittaya-theme-light-dark', label: 'Pittaya Light' },
+    { value: 'one-dark-pro-dark', label: 'One Dark Pro' },
+    { value: 'dracula-dark', label: 'Dracula' },
+    { value: 'nord-dark', label: 'Nord' },
+    { value: 'github-dark-dark', label: 'GitHub Dark' },
+    { value: 'tokyo-night-dark', label: 'Tokyo Night' },
+    { value: 'night-owl-dark', label: 'Night Owl' },
+    { value: 'shades-of-purple-dark', label: 'Shades of Purple' },
+    { value: 'webstorm-theme-dark', label: 'WebStorm' },
+    { value: 'darcula-dark', label: 'Darcula' },
+    { value: 'dark-dark', label: 'Dark' },
+    { value: 'light-dark', label: 'Light' },
+    { value: 'webstorm-darcula-dark', label: 'WebStorm Darcula' },
+    { value: 'webstorm-dark-dark', label: 'WebStorm Dark' },
+    { value: 'webstorm-darker-dark', label: 'WebStorm Darker' },
+    { value: 'webstorm-light-dark', label: 'WebStorm Light' },
+    { value: 'berlin-dark', label: 'Berlin' },
+    { value: 'bogotá-dark', label: 'Bogotá' },
+    { value: 'helsinki-dark', label: 'Helsinki' },
+    { value: 'lahabana-dark', label: 'Lahabana' },
+    { value: 'london-dark', label: 'London' },
+    { value: 'madrid-dark', label: 'Madrid' },
+    { value: 'miami-dark', label: 'Miami' },
+    { value: 'oslo-dark', label: 'Oslo' },
+    { value: 'paris-dark', label: 'Paris' },
+    { value: 'praha-dark', label: 'Praha' },
+    { value: 'tokio-dark', label: 'Tokio' },
+    { value: 'x-dark', label: 'X' },
+    { value: 'claude-dark-dark', label: 'Claude Dark' },
+    { value: 'claude-light-dark', label: 'Claude Light' },
+    { value: 'first-blush-dark', label: '晨露未干·Morning Dew' },
+    { value: 'throat-song-dark', label: '被填满的满足·Fullness' },
+    { value: 'split-open-dark', label: '撕开的温柔·Torn Tenderness' },
+    { value: 'petal-inside-dark', label: '软成一滩水·Melted' },
+    { value: 'keepers-bruise-dark', label: '你留下的颜色·Your Mark' },
+    { value: 'secret-skin-dark', label: '只属于我们的暗号·Our Secret' },
+  ]
+  const [presets, setPresets] = useState(DEFAULT_PRESETS)
+  const [presetIndex, setPresetIndex] = useState(() => {
+    try {
+      const active = localStorage.getItem('cc-haha-theme-preset') ?? ''
+      const idx = DEFAULT_PRESETS.findIndex(p => p.value === active)
+      return idx >= 0 ? idx : 0
+    } catch { return 0 }
+  })
+  const selectPreset = (index: number) => {
+    setPresetIndex(index)
+    const preset = presets[index]
+    if (preset) applyPreset(preset.value)
+  }
+  const deletePreset = () => {
+    if (presetIndex === 0) return  // can't delete "None"
+    const deleted = presets[presetIndex]
+    if (!deleted) return
+    if (!window.confirm(`Delete theme "${deleted.label}"?`)) return
+    setPresets(prev => prev.filter((_, i) => i !== presetIndex))
+    setPresetIndex(i => Math.min(i, presets.length - 2))
+    // Persist deletion
+    try {
+      const list = JSON.parse(localStorage.getItem('cc-haha-deleted-presets') ?? '[]') as string[]
+      if (deleted && !list.includes(deleted.value)) {
+        list.push(deleted.value)
+        localStorage.setItem('cc-haha-deleted-presets', JSON.stringify(list))
+      }
+    } catch { /* ignore */ }
+  }
+  const prevPreset = () => selectPreset((presetIndex - 1 + presets.length) % presets.length)
+  const nextPreset = () => selectPreset((presetIndex + 1) % presets.length)
+
   const WEB_SEARCH_MODES: Array<{ value: WebSearchMode; label: string }> = [
     { value: 'auto', label: t('settings.general.webSearch.mode.auto') },
     { value: 'tavily', label: t('settings.general.webSearch.mode.tavily') },
@@ -2603,14 +2733,14 @@ export function GeneralSettings() {
       {/* Appearance selector */}
       <h2 className="text-base font-semibold text-[var(--color-text-primary)] mb-1">{t('settings.general.appearanceTitle')}</h2>
       <p className="text-sm text-[var(--color-text-tertiary)] mb-3">{t('settings.general.appearanceDescription')}</p>
-      <div className="flex gap-2 mb-8">
+      <div className="flex items-center gap-2 mb-8">
         {THEMES.map(({ value, label }) => (
           <button
             key={value}
-            onClick={() => void setTheme(value)}
-            aria-pressed={theme === value}
-            className={`flex-1 py-2 text-xs font-semibold rounded-lg border transition-all ${
-              theme === value
+            onClick={() => { selectPreset(0); void setTheme(value) }}
+            aria-pressed={theme === value && presetIndex === 0}
+            className={`px-3 py-1.5 text-xs font-semibold rounded-lg border transition-all ${
+              theme === value && presetIndex === 0
                 ? 'bg-[image:var(--gradient-btn-primary)] text-[var(--color-btn-primary-fg)] border-transparent shadow-[var(--shadow-button-primary)]'
                 : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]'
             }`}
@@ -2618,6 +2748,37 @@ export function GeneralSettings() {
             {label}
           </button>
         ))}
+        <select
+          value={String(presetIndex)}
+          onChange={(e) => selectPreset(Number(e.target.value))}
+          className="h-8 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-2 text-xs text-[var(--color-text-primary)] outline-none"
+        >
+          {presets.map((p, i) => (
+            <option key={p.value} value={i}>{p.label}</option>
+          ))}
+        </select>
+        <button
+          onClick={prevPreset}
+          aria-label="Previous preset"
+          className="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)]"
+        >
+          <span className="material-symbols-outlined text-[14px]">keyboard_arrow_up</span>
+        </button>
+        <button
+          onClick={nextPreset}
+          aria-label="Next preset"
+          className="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)]"
+        >
+          <span className="material-symbols-outlined text-[14px]">keyboard_arrow_down</span>
+        </button>
+        <button
+          onClick={deletePreset}
+          disabled={presetIndex === 0}
+          aria-label="Remove this theme from list"
+          className="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--color-border)] text-[10px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-error)] disabled:opacity-30"
+        >
+          <span className="material-symbols-outlined text-[14px]">close</span>
+        </button>
       </div>
 
       {/* Language selector */}

--- a/desktop/src/theme/custom/blush-petal-dark.css
+++ b/desktop/src/theme/custom/blush-petal-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="blush-petal"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a080c;
+  --color-on-background: #ffe0e8;
+  --color-surface: #240c10;
+  --color-surface-dim: #1a080c;
+  --color-surface-bright: #3a1218;
+  --color-surface-container-lowest: #2a0e12;
+  --color-surface-container-low: #320f0f;
+  --color-surface-container: #301014;
+  --color-surface-container-high: #3a1218;
+  --color-surface-container-highest: #4a181c;
+  --color-surface-variant: #1d0707;
+  --color-surface-sidebar: #120406;
+  --color-surface-hover: #310f0f;
+  --color-surface-selected: #370f17;
+
+  /* 文本 */
+  --color-on-surface: #ffe0e8;
+  --color-on-surface-variant: #ffc8d8;
+  --color-text-primary: #ffe0e8;
+  --color-text-secondary: #ffe8f0;
+  --color-text-tertiary: #cc8090;
+
+  /* 品牌色 */
+  --color-primary: #e86080;
+  --color-on-primary: #1a080c;
+  --color-primary-container: #80122c;
+  --color-primary-fixed: #f2a7b9;
+  --color-primary-fixed-dim: #ec829b;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #eb7692;
+  --color-text-accent: #f4b5c4;
+
+  /* 辅色 */
+  --color-secondary: #4a181c;
+  --color-secondary-container: #240c10;
+  --color-tertiary: #e16334;
+  --color-tertiary-container: #64250e;
+
+  /* 边框 */
+  --color-outline: #92515c;
+  --color-outline-variant: #4a181c;
+  --color-border: #4a181c;
+  --color-border-focus: #e86080;
+  --color-border-separator: #320f0f;
+
+  /* 状态色 */
+  --color-error: #d03040;
+  --color-error-container: #3e0e13;
+  --color-on-error-container: #f1c2c6;
+  --color-success: #84ca84;
+  --color-success-container: #193b19;
+  --color-info: #84a7ca;
+  --color-info-container: #192a3b;
+  --color-warning: #dbc583;
+  --color-warning-container: #3f3515;
+
+  /* 反转 */
+  --color-inverse-surface: #ffe0e8;
+  --color-inverse-on-surface: #1a080c;
+  --color-inverse-primary: #f8d2db;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffe0e8db;
+  --color-text-primary-a82: #ffe0e8e5;
+  --color-text-primary-a88: #ffe0e8f2;
+  --color-text-secondary-a68: #cc8090c2;
+  --color-text-secondary-a72: #cc8090cc;
+  --color-surface-hover-a34: #310f0f57;
+  --color-surface-hover-a54: #310f0f8a;
+  --color-outline-a72: #92515ccc;
+  --color-outline-a78: #92515cdb;
+  --color-outline-a92: #92515ceb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8608040, 0 0 0 4px #e860801f;
+  --shadow-error-ring: 0 0 0 1px #d030404c, 0 0 0 4px #d0304026;
+  --shadow-button-primary: 0 8px 24px #e860804c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8608033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #c81d45);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #ec7c96, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92515c80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #240c10e5;
+  --color-sidebar-search-border: #92515c66;
+  --color-sidebar-item-hover: #320f0fe5;
+  --color-sidebar-item-active: #320f0feb;
+  --color-sidebar-item-active-border: #e8608029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a080c9e;
+  --color-surface-glass: #240c10eb;
+  --color-surface-glass-border: #2c0e104c;
+  --color-surface-info: #310f0f;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #341014;
+
+  /* 代码语法（色相: ring 346° 偏移 +20°）*/
+  --color-code-bg: #320f0f;
+  --color-code-fg: #ffe0e8;
+  --color-code-comment: #8e394a;
+  --color-code-keyword: #e86080;
+  --color-code-string: #7ebc79;
+  --color-code-function: #7979bc;
+  --color-code-number: #79b1bc;
+  --color-code-type: #95bc79;
+  --color-code-property: #ffffff;
+  --color-code-parameter: #c06377;
+  --color-code-punctuation: #b1475d;
+  --color-code-inserted: #68e342;
+  --color-code-deleted: #d03040;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffe0e8;
+  --color-diff-syntax-comment: #8e394a;
+  --color-diff-syntax-string: #7ebc79;
+  --color-diff-syntax-number: #79b1bc;
+  --color-diff-syntax-regexp: #ffffff;
+  --color-diff-syntax-keyword: #e86080;
+  --color-diff-syntax-variable: #cc8090;
+  --color-diff-syntax-parameter: #8e394a;
+  --color-diff-syntax-property: #ffffff;
+  --color-diff-syntax-function: #7979bc;
+  --color-diff-syntax-type: #95bc79;
+  --color-diff-syntax-punctuation: #8e394a;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #9bcb97;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d03040;
+  --color-diff-highlight-bg: #c63756;
+  --color-diff-highlight-gutter: #a22d46;
+  --color-diff-title-bg: #310f0f;
+  --color-diff-title-color: #cc8090;
+  --color-diff-title-border: #4a181c;
+
+  /* 终端 */
+  --color-terminal-header: #320f0f;
+  --color-terminal-bg: #1a080c;
+  --color-terminal-border: #320f0f;
+  --color-terminal-fg: #ffe0e8;
+  --color-terminal-muted: #cc8090;
+  --color-terminal-accent: #7ebc79;
+  --color-terminal-danger: #d03040;
+  --color-terminal-warning: #e86080;
+
+  /* Inspector */
+  --color-inspector-surface: #1b0909;
+  --color-inspector-panel: #320f0f;
+  --color-inspector-chip: #2a0e12;
+  --color-inspector-border: #4a181c;
+  --color-inspector-accent: #e86080;
+  --color-inspector-accent-hover: #eb7692;
+  --color-inspector-accent-secondary: #7979bc;
+  --color-inspector-text: #ffe0e8;
+  --color-inspector-heading: #ffe0e8;
+  --color-inspector-muted: #cc8090;
+  --color-inspector-muted-strong: #ffe8f0;
+  --color-inspector-success: #6ab164;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d03040;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #822334;
+  --color-inspector-danger-border: #491016;
+  --color-inspector-capacity: #92515c;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a0e12;
+  --color-activity-heat-1: #771d38;
+  --color-activity-heat-2: #df889c;
+  --color-activity-heat-3: #80122c;
+  --color-activity-heat-4: #e86080;
+  --color-activity-cell-border: #92515c52;
+  --color-activity-cell-border-hover: #e860808c;
+  --color-activity-cell-border-active: #ffe0e8;
+  --color-activity-tooltip-surface: #301014;
+  --color-activity-tooltip-border: #92515c33;
+  --color-activity-tooltip-text: #ffe0e8;
+  --color-activity-tooltip-muted: #ffffff;
+
+  /* Memory/Goal */
+  --color-memory-accent: #92515c;
+  --color-memory-surface: #2a0e12;
+  --color-memory-border: #4a181c;
+  --color-memory-icon-bg: #320f0f;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e86080;
+  --color-switch-thumb: #1a080c;
+  --color-model-option-selected-bg: #320f0f;
+  --color-model-option-selected-border: #e8608033;
+
+  /* 其他 */
+  --color-window-close-hover: #d03040;
+  --color-selection-bg: #e860804c;
+  --color-selection-fg: #ffe0e8;
+  --color-chat-navigation-target: #e860801a;
+}
+

--- a/desktop/src/theme/custom/burnt-amber-dark.css
+++ b/desktop/src/theme/custom/burnt-amber-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="burnt-amber"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a0a02;
+  --color-on-background: #ffe0c0;
+  --color-surface: #241004;
+  --color-surface-dim: #1a0a02;
+  --color-surface-bright: #3a180a;
+  --color-surface-container-lowest: #2a1206;
+  --color-surface-container-low: #371206;
+  --color-surface-container: #301408;
+  --color-surface-container-high: #3a180a;
+  --color-surface-container-highest: #4a2010;
+  --color-surface-variant: #1d0b00;
+  --color-surface-sidebar: #100600;
+  --color-surface-hover: #341305;
+  --color-surface-selected: #3d1305;
+
+  /* 文本 */
+  --color-on-surface: #ffe0c0;
+  --color-on-surface-variant: #ffd0a0;
+  --color-text-primary: #ffe0c0;
+  --color-text-secondary: #ffe8d0;
+  --color-text-tertiary: #cc9060;
+
+  /* 品牌色 */
+  --color-primary: #e88030;
+  --color-on-primary: #1a0a02;
+  --color-primary-container: #71380c;
+  --color-primary-fixed: #eea66f;
+  --color-primary-fixed-dim: #eb924e;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #ea8c44;
+  --color-text-accent: #f0ae7b;
+
+  /* 辅色 */
+  --color-secondary: #4a2010;
+  --color-secondary-container: #241004;
+  --color-tertiary: #d4c818;
+  --color-tertiary-container: #57520a;
+
+  /* 边框 */
+  --color-outline: #925e3c;
+  --color-outline-variant: #4a2010;
+  --color-border: #4a2010;
+  --color-border-focus: #e88030;
+  --color-border-separator: #371206;
+
+  /* 状态色 */
+  --color-error: #d04020;
+  --color-error-container: #3e1309;
+  --color-on-error-container: #f1b4a6;
+  --color-success: #75c375;
+  --color-success-container: #153115;
+  --color-info: #759cc3;
+  --color-info-container: #152231;
+  --color-warning: #d6bd72;
+  --color-warning-container: #342b11;
+
+  /* 反转 */
+  --color-inverse-surface: #ffe0c0;
+  --color-inverse-on-surface: #1a0a02;
+  --color-inverse-primary: #f3bd94;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffe0c0db;
+  --color-text-primary-a82: #ffe0c0e5;
+  --color-text-primary-a88: #ffe0c0f2;
+  --color-text-secondary-a68: #cc9060c2;
+  --color-text-secondary-a72: #cc9060cc;
+  --color-surface-hover-a34: #34130557;
+  --color-surface-hover-a54: #3413058a;
+  --color-outline-a72: #925e3ccc;
+  --color-outline-a78: #925e3cdb;
+  --color-outline-a92: #925e3ceb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8803040, 0 0 0 4px #e880301f;
+  --shadow-error-ring: 0 0 0 1px #d040204c, 0 0 0 4px #d0402026;
+  --shadow-button-primary: 0 8px 24px #e880304c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8803033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #b05713);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #ea8f49, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #925e3c80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #241004e5;
+  --color-sidebar-search-border: #925e3c66;
+  --color-sidebar-item-hover: #371206e5;
+  --color-sidebar-item-active: #371206eb;
+  --color-sidebar-item-active-border: #e8803029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a0a029e;
+  --color-surface-glass: #241004eb;
+  --color-surface-glass-border: #2c13094c;
+  --color-surface-info: #341305;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #341408;
+
+  /* 代码语法（色相: ring 26° 偏移 +20°）*/
+  --color-code-bg: #371206;
+  --color-code-fg: #ffe0c0;
+  --color-code-comment: #88542b;
+  --color-code-keyword: #e88030;
+  --color-code-string: #6eb767;
+  --color-code-function: #6767b7;
+  --color-code-number: #67aab7;
+  --color-code-type: #89b767;
+  --color-code-property: #fef3e7;
+  --color-code-parameter: #c37c44;
+  --color-code-punctuation: #aa6a36;
+  --color-code-inserted: #1ae171;
+  --color-code-deleted: #d04020;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffe0c0;
+  --color-diff-syntax-comment: #88542b;
+  --color-diff-syntax-string: #6eb767;
+  --color-diff-syntax-number: #67aab7;
+  --color-diff-syntax-regexp: #fef3e7;
+  --color-diff-syntax-keyword: #e88030;
+  --color-diff-syntax-variable: #cc9060;
+  --color-diff-syntax-parameter: #88542b;
+  --color-diff-syntax-property: #fef3e7;
+  --color-diff-syntax-function: #6767b7;
+  --color-diff-syntax-type: #89b767;
+  --color-diff-syntax-punctuation: #88542b;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #89c484;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d04020;
+  --color-diff-highlight-bg: #c34e0d;
+  --color-diff-highlight-gutter: #9f3f0a;
+  --color-diff-title-bg: #341305;
+  --color-diff-title-color: #cc9060;
+  --color-diff-title-border: #4a2010;
+
+  /* 终端 */
+  --color-terminal-header: #371206;
+  --color-terminal-bg: #1a0a02;
+  --color-terminal-border: #371206;
+  --color-terminal-fg: #ffe0c0;
+  --color-terminal-muted: #cc9060;
+  --color-terminal-accent: #6eb767;
+  --color-terminal-danger: #d04020;
+  --color-terminal-warning: #e88030;
+
+  /* Inspector */
+  --color-inspector-surface: #1b0b00;
+  --color-inspector-panel: #371206;
+  --color-inspector-chip: #2a1206;
+  --color-inspector-border: #4a2010;
+  --color-inspector-accent: #e88030;
+  --color-inspector-accent-hover: #ea8c44;
+  --color-inspector-accent-secondary: #6767b7;
+  --color-inspector-text: #ffe0c0;
+  --color-inspector-heading: #ffe0c0;
+  --color-inspector-muted: #cc9060;
+  --color-inspector-muted-strong: #ffe8d0;
+  --color-inspector-success: #5bad53;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d04020;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #842c03;
+  --color-inspector-danger-border: #48160b;
+  --color-inspector-capacity: #925e3c;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a1206;
+  --color-activity-heat-1: #7c2d03;
+  --color-activity-heat-2: #f26010;
+  --color-activity-heat-3: #71380c;
+  --color-activity-heat-4: #e88030;
+  --color-activity-cell-border: #925e3c52;
+  --color-activity-cell-border-hover: #e880308c;
+  --color-activity-cell-border-active: #ffe0c0;
+  --color-activity-tooltip-surface: #301408;
+  --color-activity-tooltip-border: #925e3c33;
+  --color-activity-tooltip-text: #ffe0c0;
+  --color-activity-tooltip-muted: #fef3e7;
+
+  /* Memory/Goal */
+  --color-memory-accent: #925e3c;
+  --color-memory-surface: #2a1206;
+  --color-memory-border: #4a2010;
+  --color-memory-icon-bg: #371206;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e88030;
+  --color-switch-thumb: #1a0a02;
+  --color-model-option-selected-bg: #371206;
+  --color-model-option-selected-border: #e8803033;
+
+  /* 其他 */
+  --color-window-close-hover: #d04020;
+  --color-selection-bg: #e880304c;
+  --color-selection-fg: #ffe0c0;
+  --color-chat-navigation-target: #e880301a;
+}
+

--- a/desktop/src/theme/custom/clay-earth-dark.css
+++ b/desktop/src/theme/custom/clay-earth-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="clay-earth"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #140a04;
+  --color-on-background: #f0d8c0;
+  --color-surface: #1c1008;
+  --color-surface-dim: #140a04;
+  --color-surface-bright: #341a0c;
+  --color-surface-container-lowest: #221008;
+  --color-surface-container-low: #251205;
+  --color-surface-container: #281408;
+  --color-surface-container-high: #341a0c;
+  --color-surface-container-highest: #442414;
+  --color-surface-variant: #160f00;
+  --color-surface-sidebar: #0c0602;
+  --color-surface-hover: #251105;
+  --color-surface-selected: #2b1205;
+
+  /* 文本 */
+  --color-on-surface: #f0d8c0;
+  --color-on-surface-variant: #e0c0a0;
+  --color-text-primary: #f0d8c0;
+  --color-text-secondary: #f0e0d0;
+  --color-text-tertiary: #b88a64;
+
+  /* 品牌色 */
+  --color-primary: #c07030;
+  --color-on-primary: #140a04;
+  --color-primary-container: #563215;
+  --color-primary-fixed: #d48f57;
+  --color-primary-fixed-dim: #ce7e3e;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #cc7936;
+  --color-text-accent: #d79560;
+
+  /* 辅色 */
+  --color-secondary: #442414;
+  --color-secondary-container: #1c1008;
+  --color-tertiary: #a39b28;
+  --color-tertiary-container: #434010;
+
+  /* 边框 */
+  --color-outline: #845c40;
+  --color-outline-variant: #442414;
+  --color-border: #442414;
+  --color-border-focus: #c07030;
+  --color-border-separator: #251205;
+
+  /* 状态色 */
+  --color-error: #b04020;
+  --color-error-container: #341309;
+  --color-on-error-container: #e6927a;
+  --color-success: #6dc06d;
+  --color-success-container: #122a12;
+  --color-info: #6d97c0;
+  --color-info-container: #121d2a;
+  --color-warning: #d3b96a;
+  --color-warning-container: #2c250f;
+
+  /* 反转 */
+  --color-inverse-surface: #f0d8c0;
+  --color-inverse-on-surface: #140a04;
+  --color-inverse-primary: #dca273;
+
+  /* 透明度 */
+  --color-text-primary-a78: #f0d8c0db;
+  --color-text-primary-a82: #f0d8c0e5;
+  --color-text-primary-a88: #f0d8c0f2;
+  --color-text-secondary-a68: #b88a64c2;
+  --color-text-secondary-a72: #b88a64cc;
+  --color-surface-hover-a34: #25110557;
+  --color-surface-hover-a54: #2511058a;
+  --color-outline-a72: #845c40cc;
+  --color-outline-a78: #845c40db;
+  --color-outline-a92: #845c40eb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #c0703040, 0 0 0 4px #c070301f;
+  --shadow-error-ring: 0 0 0 1px #b040204c, 0 0 0 4px #b0402026;
+  --shadow-button-primary: 0 8px 24px #c070304c;
+  --shadow-activity-cell-hover: 0 0 0 2px #c0703033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #864e21);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #cd7b3a, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #845c4080;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #1c1008e5;
+  --color-sidebar-search-border: #845c4066;
+  --color-sidebar-item-hover: #251205e5;
+  --color-sidebar-item-active: #251205eb;
+  --color-sidebar-item-active-border: #c0703029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #140a049e;
+  --color-surface-glass: #1c1008eb;
+  --color-surface-glass-border: #28150c4c;
+  --color-surface-info: #251105;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #2c1408;
+
+  /* 代码语法（色相: ring 27° 偏移 +20°）*/
+  --color-code-bg: #251205;
+  --color-code-fg: #f0d8c0;
+  --color-code-comment: #745235;
+  --color-code-keyword: #c07030;
+  --color-code-string: #70a96b;
+  --color-code-function: #6b6ba9;
+  --color-code-number: #6b9fa9;
+  --color-code-type: #85a96b;
+  --color-code-property: #f5ebe0;
+  --color-code-parameter: #ab784e;
+  --color-code-punctuation: #926642;
+  --color-code-inserted: #2bac64;
+  --color-code-deleted: #b04020;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #f0d8c0;
+  --color-diff-syntax-comment: #745235;
+  --color-diff-syntax-string: #70a96b;
+  --color-diff-syntax-number: #6b9fa9;
+  --color-diff-syntax-regexp: #f5ebe0;
+  --color-diff-syntax-keyword: #c07030;
+  --color-diff-syntax-variable: #b88a64;
+  --color-diff-syntax-parameter: #745235;
+  --color-diff-syntax-property: #f5ebe0;
+  --color-diff-syntax-function: #6b6ba9;
+  --color-diff-syntax-type: #85a96b;
+  --color-diff-syntax-punctuation: #745235;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #89b885;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #b04020;
+  --color-diff-highlight-bg: #834118;
+  --color-diff-highlight-gutter: #6b3513;
+  --color-diff-title-bg: #251105;
+  --color-diff-title-color: #b88a64;
+  --color-diff-title-border: #442414;
+
+  /* 终端 */
+  --color-terminal-header: #251205;
+  --color-terminal-bg: #140a04;
+  --color-terminal-border: #251205;
+  --color-terminal-fg: #f0d8c0;
+  --color-terminal-muted: #b88a64;
+  --color-terminal-accent: #70a96b;
+  --color-terminal-danger: #b04020;
+  --color-terminal-warning: #c07030;
+
+  /* Inspector */
+  --color-inspector-surface: #1a0800;
+  --color-inspector-panel: #251205;
+  --color-inspector-chip: #221008;
+  --color-inspector-border: #442414;
+  --color-inspector-accent: #c07030;
+  --color-inspector-accent-hover: #cc7936;
+  --color-inspector-accent-secondary: #6b6ba9;
+  --color-inspector-text: #f0d8c0;
+  --color-inspector-heading: #f0d8c0;
+  --color-inspector-muted: #b88a64;
+  --color-inspector-muted-strong: #f0e0d0;
+  --color-inspector-success: #609d5b;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #b04020;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #59260e;
+  --color-inspector-danger-border: #3d160b;
+  --color-inspector-capacity: #845c40;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #221008;
+  --color-activity-heat-1: #4f2609;
+  --color-activity-heat-2: #ad5820;
+  --color-activity-heat-3: #563215;
+  --color-activity-heat-4: #c07030;
+  --color-activity-cell-border: #845c4052;
+  --color-activity-cell-border-hover: #c070308c;
+  --color-activity-cell-border-active: #f0d8c0;
+  --color-activity-tooltip-surface: #281408;
+  --color-activity-tooltip-border: #845c4033;
+  --color-activity-tooltip-text: #f0d8c0;
+  --color-activity-tooltip-muted: #f5ebe0;
+
+  /* Memory/Goal */
+  --color-memory-accent: #845c40;
+  --color-memory-surface: #221008;
+  --color-memory-border: #442414;
+  --color-memory-icon-bg: #251205;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #c07030;
+  --color-switch-thumb: #140a04;
+  --color-model-option-selected-bg: #251205;
+  --color-model-option-selected-border: #c0703033;
+
+  /* 其他 */
+  --color-window-close-hover: #b04020;
+  --color-selection-bg: #c070304c;
+  --color-selection-fg: #f0d8c0;
+  --color-chat-navigation-target: #c070301a;
+}
+

--- a/desktop/src/theme/custom/coral-blush-dark.css
+++ b/desktop/src/theme/custom/coral-blush-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="coral-blush"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a060c;
+  --color-on-background: #ffd8e0;
+  --color-surface: #240a10;
+  --color-surface-dim: #1a060c;
+  --color-surface-bright: #3a1218;
+  --color-surface-container-lowest: #2a0c12;
+  --color-surface-container-low: #3d0914;
+  --color-surface-container: #300e14;
+  --color-surface-container-high: #3a1218;
+  --color-surface-container-highest: #4a1620;
+  --color-surface-variant: #350011;
+  --color-surface-sidebar: #100408;
+  --color-surface-hover: #3c0912;
+  --color-surface-selected: #340f15;
+
+  /* 文本 */
+  --color-on-surface: #ffd8e0;
+  --color-on-surface-variant: #ffc0d0;
+  --color-text-primary: #ffd8e0;
+  --color-text-secondary: #ffe4ec;
+  --color-text-tertiary: #cc8090;
+
+  /* 品牌色 */
+  --color-primary: #e86088;
+  --color-on-primary: #1a060c;
+  --color-primary-container: #801233;
+  --color-primary-fixed: #f2a7bd;
+  --color-primary-fixed-dim: #ec82a1;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #eb7699;
+  --color-text-accent: #f4b5c8;
+
+  /* 辅色 */
+  --color-secondary: #4a1620;
+  --color-secondary-container: #240a10;
+  --color-tertiary: #e15734;
+  --color-tertiary-container: #641f0e;
+
+  /* 边框 */
+  --color-outline: #92505e;
+  --color-outline-variant: #4a1620;
+  --color-border: #4a1620;
+  --color-border-focus: #e86088;
+  --color-border-separator: #3d0914;
+
+  /* 状态色 */
+  --color-error: #d03048;
+  --color-error-container: #3e0e15;
+  --color-on-error-container: #f1c2c9;
+  --color-success: #80c880;
+  --color-success-container: #183718;
+  --color-info: #80a4c8;
+  --color-info-container: #182737;
+  --color-warning: #d9c37f;
+  --color-warning-container: #3c3214;
+
+  /* 反转 */
+  --color-inverse-surface: #ffd8e0;
+  --color-inverse-on-surface: #1a060c;
+  --color-inverse-primary: #f8d2dd;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffd8e0db;
+  --color-text-primary-a82: #ffd8e0e5;
+  --color-text-primary-a88: #ffd8e0f2;
+  --color-text-secondary-a68: #cc8090c2;
+  --color-text-secondary-a72: #cc8090cc;
+  --color-surface-hover-a34: #3c091257;
+  --color-surface-hover-a54: #3c09128a;
+  --color-outline-a72: #92505ecc;
+  --color-outline-a78: #92505edb;
+  --color-outline-a92: #92505eeb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8608840, 0 0 0 4px #e860881f;
+  --shadow-error-ring: 0 0 0 1px #d030484c, 0 0 0 4px #d0304826;
+  --shadow-button-primary: 0 8px 24px #e860884c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8608833, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #c81d4f);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #ec7c9d, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92505e80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #240a10e5;
+  --color-sidebar-search-border: #92505e66;
+  --color-sidebar-item-hover: #3d0914e5;
+  --color-sidebar-item-active: #3d0914eb;
+  --color-sidebar-item-active-border: #e8608829;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a060c9e;
+  --color-surface-glass: #240a10eb;
+  --color-surface-glass-border: #2c0d134c;
+  --color-surface-info: #3c0912;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #340e14;
+
+  /* 代码语法（色相: ring 342° 偏移 +20°）*/
+  --color-code-bg: #3d0914;
+  --color-code-fg: #ffd8e0;
+  --color-code-comment: #8e394a;
+  --color-code-keyword: #e86088;
+  --color-code-string: #7bba75;
+  --color-code-function: #7575ba;
+  --color-code-number: #75afba;
+  --color-code-type: #92ba75;
+  --color-code-property: #fffcfc;
+  --color-code-parameter: #c06377;
+  --color-code-punctuation: #b1475d;
+  --color-code-inserted: #72e342;
+  --color-code-deleted: #d03048;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffd8e0;
+  --color-diff-syntax-comment: #8e394a;
+  --color-diff-syntax-string: #7bba75;
+  --color-diff-syntax-number: #75afba;
+  --color-diff-syntax-regexp: #fffcfc;
+  --color-diff-syntax-keyword: #e86088;
+  --color-diff-syntax-variable: #cc8090;
+  --color-diff-syntax-parameter: #8e394a;
+  --color-diff-syntax-property: #fffcfc;
+  --color-diff-syntax-function: #7575ba;
+  --color-diff-syntax-type: #92ba75;
+  --color-diff-syntax-punctuation: #8e394a;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #97c993;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d03048;
+  --color-diff-highlight-bg: #d52e5d;
+  --color-diff-highlight-gutter: #b0234b;
+  --color-diff-title-bg: #3c0912;
+  --color-diff-title-color: #cc8090;
+  --color-diff-title-border: #4a1620;
+
+  /* 终端 */
+  --color-terminal-header: #3d0914;
+  --color-terminal-bg: #1a060c;
+  --color-terminal-border: #3d0914;
+  --color-terminal-fg: #ffd8e0;
+  --color-terminal-muted: #cc8090;
+  --color-terminal-accent: #7bba75;
+  --color-terminal-danger: #d03048;
+  --color-terminal-warning: #e86088;
+
+  /* Inspector */
+  --color-inspector-surface: #31000f;
+  --color-inspector-panel: #3d0914;
+  --color-inspector-chip: #2a0c12;
+  --color-inspector-border: #4a1620;
+  --color-inspector-accent: #e86088;
+  --color-inspector-accent-hover: #eb7699;
+  --color-inspector-accent-secondary: #7575ba;
+  --color-inspector-text: #ffd8e0;
+  --color-inspector-heading: #ffd8e0;
+  --color-inspector-muted: #cc8090;
+  --color-inspector-muted-strong: #ffe4ec;
+  --color-inspector-success: #67af60;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d03048;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #8f1b3f;
+  --color-inspector-danger-border: #491019;
+  --color-inspector-capacity: #92505e;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a0c12;
+  --color-activity-heat-1: #86173b;
+  --color-activity-heat-2: #e4829f;
+  --color-activity-heat-3: #801233;
+  --color-activity-heat-4: #e86088;
+  --color-activity-cell-border: #92505e52;
+  --color-activity-cell-border-hover: #e860888c;
+  --color-activity-cell-border-active: #ffd8e0;
+  --color-activity-tooltip-surface: #300e14;
+  --color-activity-tooltip-border: #92505e33;
+  --color-activity-tooltip-text: #ffd8e0;
+  --color-activity-tooltip-muted: #fffcfc;
+
+  /* Memory/Goal */
+  --color-memory-accent: #92505e;
+  --color-memory-surface: #2a0c12;
+  --color-memory-border: #4a1620;
+  --color-memory-icon-bg: #3d0914;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e86088;
+  --color-switch-thumb: #1a060c;
+  --color-model-option-selected-bg: #3d0914;
+  --color-model-option-selected-border: #e8608833;
+
+  /* 其他 */
+  --color-window-close-hover: #d03048;
+  --color-selection-bg: #e860884c;
+  --color-selection-fg: #ffd8e0;
+  --color-chat-navigation-target: #e860881a;
+}
+

--- a/desktop/src/theme/custom/dawn-flush-dark.css
+++ b/desktop/src/theme/custom/dawn-flush-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="dawn-flush"] {
+  color-scheme: light;
+
+  /* Surface 层级 */
+  --color-background: #faf4f2;
+  --color-on-background: #4a3038;
+  --color-surface: #f8f0ee;
+  --color-surface-dim: #faf4f2;
+  --color-surface-bright: #f0e0e0;
+  --color-surface-container-lowest: #faf4f2;
+  --color-surface-container-low: #dadada;
+  --color-surface-container: #e8d4d8;
+  --color-surface-container-high: #f0e0e0;
+  --color-surface-container-highest: #f8f0ee;
+  --color-surface-variant: #e6e6e6;
+  --color-surface-sidebar: #f4ece8;
+  --color-surface-hover: #dedede;
+  --color-surface-selected: #c9c9c9;
+
+  /* 文本 */
+  --color-on-surface: #4a3038;
+  --color-on-surface-variant: #5a4048;
+  --color-text-primary: #4a3038;
+  --color-text-secondary: #4a3038;
+  --color-text-tertiary: #8a7078;
+
+  /* 品牌色 */
+  --color-primary: #d4a0a8;
+  --color-on-primary: #faf4f2;
+  --color-primary-container: #73343d;
+  --color-primary-fixed: #f0e0e2;
+  --color-primary-fixed-dim: #e1bec4;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #ddb4ba;
+  --color-text-accent: #f6ecee;
+
+  /* 辅色 */
+  --color-secondary: #f8f0ee;
+  --color-secondary-container: #f8f0ee;
+  --color-tertiary: #c29279;
+  --color-tertiary-container: #593928;
+
+  /* 边框 */
+  --color-outline: #ad989e;
+  --color-outline-variant: #d8c8cc;
+  --color-border: #d8c8cc;
+  --color-border-focus: #d4a0a8;
+  --color-border-separator: #dadada;
+
+  /* 状态色 */
+  --color-error: #c04050;
+  --color-error-container: #391317;
+  --color-on-error-container: #ecc6cb;
+  --color-success: #53cd53;
+  --color-success-container: #c9e8c9;
+  --color-info: #5390cd;
+  --color-info-container: #c9d8e8;
+  --color-warning: #e0bb4f;
+  --color-warning-container: #ebe2c5;
+
+  /* 反转 */
+  --color-inverse-surface: #4a3038;
+  --color-inverse-on-surface: #faf4f2;
+  --color-inverse-primary: #ffffff;
+
+  /* 透明度 */
+  --color-text-primary-a78: #4a3038c9;
+  --color-text-primary-a82: #4a3038d3;
+  --color-text-primary-a88: #4a3038e2;
+  --color-text-secondary-a68: #8a7078af;
+  --color-text-secondary-a72: #8a7078b9;
+  --color-surface-hover-a34: #dedede57;
+  --color-surface-hover-a54: #dedede8a;
+  --color-outline-a72: #ad989eb9;
+  --color-outline-a78: #ad989ec9;
+  --color-outline-a92: #ad989eeb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #d4a0a840, 0 0 0 4px #d4a0a81f;
+  --shadow-error-ring: 0 0 0 1px #c040504c, 0 0 0 4px #c0405026;
+  --shadow-button-primary: 0 8px 24px #d4a0a84c;
+  --shadow-activity-cell-hover: 0 0 0 2px #d4a0a833, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #b15361);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #dfb9bf, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #ad989e80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #f8f0eed3;
+  --color-sidebar-search-border: #ad989e66;
+  --color-sidebar-item-hover: #dadadad3;
+  --color-sidebar-item-active: #dadadaeb;
+  --color-sidebar-item-active-border: #d4a0a829;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #faf4f29e;
+  --color-surface-glass: #f8f0eeeb;
+  --color-surface-glass-border: #9267724c;
+  --color-surface-info: #dedede;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #f0e8e4;
+
+  /* 代码语法（色相: ring 351° 偏移 +20°）*/
+  --color-code-bg: #dadada;
+  --color-code-fg: #4a3038;
+  --color-code-comment: #524347;
+  --color-code-keyword: #d4a0a8;
+  --color-code-string: #66a660;
+  --color-code-function: #6060a6;
+  --color-code-number: #609aa6;
+  --color-code-type: #7da660;
+  --color-code-property: #4d323a;
+  --color-code-parameter: #796269;
+  --color-code-punctuation: #675359;
+  --color-code-inserted: #90c886;
+  --color-code-deleted: #c04050;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #4a3038;
+  --color-diff-syntax-comment: #524347;
+  --color-diff-syntax-string: #66a660;
+  --color-diff-syntax-number: #609aa6;
+  --color-diff-syntax-regexp: #4d323a;
+  --color-diff-syntax-keyword: #d4a0a8;
+  --color-diff-syntax-variable: #8a7078;
+  --color-diff-syntax-parameter: #524347;
+  --color-diff-syntax-property: #4d323a;
+  --color-diff-syntax-function: #6060a6;
+  --color-diff-syntax-type: #7da660;
+  --color-diff-syntax-punctuation: #524347;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #e8f5e2;
+  --color-diff-added-word: #b8e4a8;
+  --color-diff-added-gutter: #d4edca;
+  --color-diff-added-text: #7eb479;
+  --color-diff-removed-bg: #fdecea;
+  --color-diff-removed-word: #f5b8b4;
+  --color-diff-removed-gutter: #f9d4d0;
+  --color-diff-removed-text: #c04050;
+  --color-diff-highlight-bg: #fff5d6;
+  --color-diff-highlight-gutter: #ffe081;
+  --color-diff-title-bg: #dedede;
+  --color-diff-title-color: #8a7078;
+  --color-diff-title-border: #d8c8cc;
+
+  /* 终端 */
+  --color-terminal-header: #dadada;
+  --color-terminal-bg: #faf4f2;
+  --color-terminal-border: #dadada;
+  --color-terminal-fg: #4a3038;
+  --color-terminal-muted: #8a7078;
+  --color-terminal-accent: #66a660;
+  --color-terminal-danger: #c04050;
+  --color-terminal-warning: #d4a0a8;
+
+  /* Inspector */
+  --color-inspector-surface: #e6e6e6;
+  --color-inspector-panel: #dadada;
+  --color-inspector-chip: #faf4f2;
+  --color-inspector-border: #d8c8cc;
+  --color-inspector-accent: #d4a0a8;
+  --color-inspector-accent-hover: #ddb4ba;
+  --color-inspector-accent-secondary: #6060a6;
+  --color-inspector-text: #4a3038;
+  --color-inspector-heading: #4a3038;
+  --color-inspector-muted: #8a7078;
+  --color-inspector-muted-strong: #4a3038;
+  --color-inspector-success: #5a9754;
+  --color-inspector-success-bg: #e8f5e2;
+  --color-inspector-danger: #c04050;
+  --color-inspector-danger-bg: #fdecea;
+  --color-inspector-danger-surface: #d1d1d1;
+  --color-inspector-danger-border: #43161b;
+  --color-inspector-capacity: #ad989e;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #faf4f2;
+  --color-activity-heat-1: #e1e1e1;
+  --color-activity-heat-2: #d2d2d2;
+  --color-activity-heat-3: #73343d;
+  --color-activity-heat-4: #d4a0a8;
+  --color-activity-cell-border: #ad989e52;
+  --color-activity-cell-border-hover: #d4a0a88c;
+  --color-activity-cell-border-active: #4a3038;
+  --color-activity-tooltip-surface: #e8d4d8;
+  --color-activity-tooltip-border: #ad989e33;
+  --color-activity-tooltip-text: #4a3038;
+  --color-activity-tooltip-muted: #4d323a;
+
+  /* Memory/Goal */
+  --color-memory-accent: #ad989e;
+  --color-memory-surface: #faf4f2;
+  --color-memory-border: #d8c8cc;
+  --color-memory-icon-bg: #dadada;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #d4a0a8;
+  --color-switch-thumb: #faf4f2;
+  --color-model-option-selected-bg: #dadada;
+  --color-model-option-selected-border: #d4a0a833;
+
+  /* 其他 */
+  --color-window-close-hover: #c04050;
+  --color-selection-bg: #d4a0a84c;
+  --color-selection-fg: #4a3038;
+  --color-chat-navigation-target: #d4a0a81a;
+}
+

--- a/desktop/src/theme/custom/deep-crimson-dark.css
+++ b/desktop/src/theme/custom/deep-crimson-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="deep-crimson"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a0204;
+  --color-on-background: #ffc8d0;
+  --color-surface: #240508;
+  --color-surface-dim: #1a0204;
+  --color-surface-bright: #3a0c14;
+  --color-surface-container-lowest: #2a060c;
+  --color-surface-container-low: #52000d;
+  --color-surface-container: #300810;
+  --color-surface-container-high: #3a0c14;
+  --color-surface-container-highest: #4a101c;
+  --color-surface-variant: #2c0000;
+  --color-surface-sidebar: #120002;
+  --color-surface-hover: #51000a;
+  --color-surface-selected: #360812;
+
+  /* 文本 */
+  --color-on-surface: #ffc8d0;
+  --color-on-surface-variant: #ffa0b0;
+  --color-text-primary: #ffc8d0;
+  --color-text-secondary: #ffd0d8;
+  --color-text-tertiary: #cc6e7a;
+
+  /* 品牌色 */
+  --color-primary: #e84060;
+  --color-on-primary: #1a0204;
+  --color-primary-container: #760e22;
+  --color-primary-fixed: #ef8296;
+  --color-primary-fixed-dim: #eb5f7a;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #ea5571;
+  --color-text-accent: #f18fa1;
+
+  /* 辅色 */
+  --color-secondary: #4a101c;
+  --color-secondary-container: #240508;
+  --color-tertiary: #de581b;
+  --color-tertiary-container: #5b240b;
+
+  /* 边框 */
+  --color-outline: #924450;
+  --color-outline-variant: #4a101c;
+  --color-border: #4a101c;
+  --color-border-focus: #e84060;
+  --color-border-separator: #52000d;
+
+  /* 状态色 */
+  --color-error: #e02030;
+  --color-error-container: #43090e;
+  --color-on-error-container: #f5bdc2;
+  --color-success: #78c578;
+  --color-success-container: #153115;
+  --color-info: #789fc5;
+  --color-info-container: #152231;
+  --color-warning: #d7bf76;
+  --color-warning-container: #342b11;
+
+  /* 反转 */
+  --color-inverse-surface: #ffc8d0;
+  --color-inverse-on-surface: #1a0204;
+  --color-inverse-primary: #f4a9b7;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffc8d0db;
+  --color-text-primary-a82: #ffc8d0e5;
+  --color-text-primary-a88: #ffc8d0f2;
+  --color-text-secondary-a68: #cc6e7ac2;
+  --color-text-secondary-a72: #cc6e7acc;
+  --color-surface-hover-a34: #51000a57;
+  --color-surface-hover-a54: #51000a8a;
+  --color-outline-a72: #924450cc;
+  --color-outline-a78: #924450db;
+  --color-outline-a92: #924450eb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8406040, 0 0 0 4px #e840601f;
+  --shadow-error-ring: 0 0 0 1px #e020304c, 0 0 0 4px #e0203026;
+  --shadow-button-primary: 0 8px 24px #e840604c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8406033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #b81635);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #eb5a75, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92445080;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #240508e5;
+  --color-sidebar-search-border: #92445066;
+  --color-sidebar-item-hover: #52000de5;
+  --color-sidebar-item-active: #52000deb;
+  --color-sidebar-item-active-border: #e8406029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a02049e;
+  --color-surface-glass: #240508eb;
+  --color-surface-glass-border: #2c09104c;
+  --color-surface-info: #51000a;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #340810;
+
+  /* 代码语法（色相: ring 349° 偏移 +20°）*/
+  --color-code-bg: #52000d;
+  --color-code-fg: #ffc8d0;
+  --color-code-comment: #8b313c;
+  --color-code-keyword: #e84060;
+  --color-code-string: #72b86b;
+  --color-code-function: #6b6bb8;
+  --color-code-number: #6babb8;
+  --color-code-type: #8bb86b;
+  --color-code-property: #fee7eb;
+  --color-code-parameter: #c25260;
+  --color-code-punctuation: #ae3d4b;
+  --color-code-inserted: #4ae325;
+  --color-code-deleted: #e02030;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffc8d0;
+  --color-diff-syntax-comment: #8b313c;
+  --color-diff-syntax-string: #72b86b;
+  --color-diff-syntax-number: #6babb8;
+  --color-diff-syntax-regexp: #fee7eb;
+  --color-diff-syntax-keyword: #e84060;
+  --color-diff-syntax-variable: #cc6e7a;
+  --color-diff-syntax-parameter: #8b313c;
+  --color-diff-syntax-property: #fee7eb;
+  --color-diff-syntax-function: #6b6bb8;
+  --color-diff-syntax-type: #8bb86b;
+  --color-diff-syntax-punctuation: #8b313c;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #8ec688;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #e02030;
+  --color-diff-highlight-bg: #ee0d21;
+  --color-diff-highlight-gutter: #c30a1b;
+  --color-diff-title-bg: #51000a;
+  --color-diff-title-color: #cc6e7a;
+  --color-diff-title-border: #4a101c;
+
+  /* 终端 */
+  --color-terminal-header: #52000d;
+  --color-terminal-bg: #1a0204;
+  --color-terminal-border: #52000d;
+  --color-terminal-fg: #ffc8d0;
+  --color-terminal-muted: #cc6e7a;
+  --color-terminal-accent: #72b86b;
+  --color-terminal-danger: #e02030;
+  --color-terminal-warning: #e84060;
+
+  /* Inspector */
+  --color-inspector-surface: #2a0000;
+  --color-inspector-panel: #52000d;
+  --color-inspector-chip: #2a060c;
+  --color-inspector-border: #4a101c;
+  --color-inspector-accent: #e84060;
+  --color-inspector-accent-hover: #ea5571;
+  --color-inspector-accent-secondary: #6b6bb8;
+  --color-inspector-text: #ffc8d0;
+  --color-inspector-heading: #ffc8d0;
+  --color-inspector-muted: #cc6e7a;
+  --color-inspector-muted-strong: #ffd0d8;
+  --color-inspector-success: #5fae57;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #e02030;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #e3071f;
+  --color-inspector-danger-border: #4e0a10;
+  --color-inspector-capacity: #924450;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a060c;
+  --color-activity-heat-1: #a00511;
+  --color-activity-heat-2: #f24858;
+  --color-activity-heat-3: #760e22;
+  --color-activity-heat-4: #e84060;
+  --color-activity-cell-border: #92445052;
+  --color-activity-cell-border-hover: #e840608c;
+  --color-activity-cell-border-active: #ffc8d0;
+  --color-activity-tooltip-surface: #300810;
+  --color-activity-tooltip-border: #92445033;
+  --color-activity-tooltip-text: #ffc8d0;
+  --color-activity-tooltip-muted: #fee7eb;
+
+  /* Memory/Goal */
+  --color-memory-accent: #924450;
+  --color-memory-surface: #2a060c;
+  --color-memory-border: #4a101c;
+  --color-memory-icon-bg: #52000d;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e84060;
+  --color-switch-thumb: #1a0204;
+  --color-model-option-selected-bg: #52000d;
+  --color-model-option-selected-border: #e8406033;
+
+  /* 其他 */
+  --color-window-close-hover: #e02030;
+  --color-selection-bg: #e840604c;
+  --color-selection-fg: #ffc8d0;
+  --color-chat-navigation-target: #e840601a;
+}
+

--- a/desktop/src/theme/custom/dusk-magenta-dark.css
+++ b/desktop/src/theme/custom/dusk-magenta-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="dusk-magenta"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #180612;
+  --color-on-background: #ffc8e8;
+  --color-surface: #220818;
+  --color-surface-dim: #180612;
+  --color-surface-bright: #380e28;
+  --color-surface-container-lowest: #280a1c;
+  --color-surface-container-low: #350823;
+  --color-surface-container: #2e0a20;
+  --color-surface-container-high: #380e28;
+  --color-surface-container-highest: #481230;
+  --color-surface-variant: #2d001f;
+  --color-surface-sidebar: #10040c;
+  --color-surface-hover: #350822;
+  --color-surface-selected: #380825;
+
+  /* 文本 */
+  --color-on-surface: #ffc8e8;
+  --color-on-surface-variant: #ffa0d8;
+  --color-text-primary: #ffc8e8;
+  --color-text-secondary: #ffd8f0;
+  --color-text-tertiary: #cc70a0;
+
+  /* 品牌色 */
+  --color-primary: #e050a0;
+  --color-on-primary: #180612;
+  --color-primary-container: #741449;
+  --color-primary-fixed: #eb90c3;
+  --color-primary-fixed-dim: #e56eb0;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #e364ab;
+  --color-text-accent: #ed9dca;
+
+  /* 辅色 */
+  --color-secondary: #481230;
+  --color-secondary-container: #220818;
+  --color-tertiary: #d92931;
+  --color-tertiary-container: #5a1013;
+
+  /* 边框 */
+  --color-outline: #91466e;
+  --color-outline-variant: #481230;
+  --color-border: #481230;
+  --color-border-focus: #e050a0;
+  --color-border-separator: #350823;
+
+  /* 状态色 */
+  --color-error: #d03050;
+  --color-error-container: #3e0e17;
+  --color-on-error-container: #f1c2cb;
+  --color-success: #79c579;
+  --color-success-container: #163416;
+  --color-info: #799fc5;
+  --color-info-container: #162534;
+  --color-warning: #d7bf76;
+  --color-warning-container: #382e12;
+
+  /* 反转 */
+  --color-inverse-surface: #ffc8e8;
+  --color-inverse-on-surface: #180612;
+  --color-inverse-primary: #f2b7d8;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffc8e8db;
+  --color-text-primary-a82: #ffc8e8e5;
+  --color-text-primary-a88: #ffc8e8f2;
+  --color-text-secondary-a68: #cc70a0c2;
+  --color-text-secondary-a72: #cc70a0cc;
+  --color-surface-hover-a34: #35082257;
+  --color-surface-hover-a54: #3508228a;
+  --color-outline-a72: #91466ecc;
+  --color-outline-a78: #91466edb;
+  --color-outline-a92: #91466eeb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e050a040, 0 0 0 4px #e050a01f;
+  --shadow-error-ring: 0 0 0 1px #d030504c, 0 0 0 4px #d0305026;
+  --shadow-button-primary: 0 8px 24px #e050a04c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e050a033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #b42072);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #e469ae, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #91466e80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #220818e5;
+  --color-sidebar-search-border: #91466e66;
+  --color-sidebar-item-hover: #350823e5;
+  --color-sidebar-item-active: #350823eb;
+  --color-sidebar-item-active-border: #e050a029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1806129e;
+  --color-surface-glass: #220818eb;
+  --color-surface-glass-border: #2b0a1c4c;
+  --color-surface-info: #350822;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #300c20;
+
+  /* 代码语法（色相: ring 327° 偏移 +20°）*/
+  --color-code-bg: #350823;
+  --color-code-fg: #ffc8e8;
+  --color-code-comment: #8b3160;
+  --color-code-keyword: #e050a0;
+  --color-code-string: #76b470;
+  --color-code-function: #7070b4;
+  --color-code-number: #70a9b4;
+  --color-code-type: #8db470;
+  --color-code-property: #feeff9;
+  --color-code-parameter: #c2548d;
+  --color-code-punctuation: #ae3e78;
+  --color-code-inserted: #91db36;
+  --color-code-deleted: #d03050;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffc8e8;
+  --color-diff-syntax-comment: #8b3160;
+  --color-diff-syntax-string: #76b470;
+  --color-diff-syntax-number: #70a9b4;
+  --color-diff-syntax-regexp: #feeff9;
+  --color-diff-syntax-keyword: #e050a0;
+  --color-diff-syntax-variable: #cc70a0;
+  --color-diff-syntax-parameter: #8b3160;
+  --color-diff-syntax-property: #feeff9;
+  --color-diff-syntax-function: #7070b4;
+  --color-diff-syntax-type: #8db470;
+  --color-diff-syntax-punctuation: #8b3160;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #91c38c;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d03050;
+  --color-diff-highlight-bg: #b82786;
+  --color-diff-highlight-gutter: #961f6d;
+  --color-diff-title-bg: #350822;
+  --color-diff-title-color: #cc70a0;
+  --color-diff-title-border: #481230;
+
+  /* 终端 */
+  --color-terminal-header: #350823;
+  --color-terminal-bg: #180612;
+  --color-terminal-border: #350823;
+  --color-terminal-fg: #ffc8e8;
+  --color-terminal-muted: #cc70a0;
+  --color-terminal-accent: #76b470;
+  --color-terminal-danger: #d03050;
+  --color-terminal-warning: #e050a0;
+
+  /* Inspector */
+  --color-inspector-surface: #2b001d;
+  --color-inspector-panel: #350823;
+  --color-inspector-chip: #280a1c;
+  --color-inspector-border: #481230;
+  --color-inspector-accent: #e050a0;
+  --color-inspector-accent-hover: #e364ab;
+  --color-inspector-accent-secondary: #7070b4;
+  --color-inspector-text: #ffc8e8;
+  --color-inspector-heading: #ffc8e8;
+  --color-inspector-muted: #cc70a0;
+  --color-inspector-muted-strong: #ffd8f0;
+  --color-inspector-success: #63a95c;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d03050;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #881b61;
+  --color-inspector-danger-border: #49101b;
+  --color-inspector-capacity: #91466e;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #280a1c;
+  --color-activity-heat-1: #6d164d;
+  --color-activity-heat-2: #d74fa3;
+  --color-activity-heat-3: #741449;
+  --color-activity-heat-4: #e050a0;
+  --color-activity-cell-border: #91466e52;
+  --color-activity-cell-border-hover: #e050a08c;
+  --color-activity-cell-border-active: #ffc8e8;
+  --color-activity-tooltip-surface: #2e0a20;
+  --color-activity-tooltip-border: #91466e33;
+  --color-activity-tooltip-text: #ffc8e8;
+  --color-activity-tooltip-muted: #feeff9;
+
+  /* Memory/Goal */
+  --color-memory-accent: #91466e;
+  --color-memory-surface: #280a1c;
+  --color-memory-border: #481230;
+  --color-memory-icon-bg: #350823;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e050a0;
+  --color-switch-thumb: #180612;
+  --color-model-option-selected-bg: #350823;
+  --color-model-option-selected-border: #e050a033;
+
+  /* 其他 */
+  --color-window-close-hover: #d03050;
+  --color-selection-bg: #e050a04c;
+  --color-selection-fg: #ffc8e8;
+  --color-chat-navigation-target: #e050a01a;
+}
+

--- a/desktop/src/theme/custom/midnight-plum-dark.css
+++ b/desktop/src/theme/custom/midnight-plum-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="midnight-plum"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a0410;
+  --color-on-background: #ffc8e0;
+  --color-surface: #240818;
+  --color-surface-dim: #1a0410;
+  --color-surface-bright: #3a1028;
+  --color-surface-container-lowest: #2a0a1c;
+  --color-surface-container-low: #390825;
+  --color-surface-container: #300c20;
+  --color-surface-container-high: #3a1028;
+  --color-surface-container-highest: #4a1430;
+  --color-surface-variant: #2d001f;
+  --color-surface-sidebar: #100208;
+  --color-surface-hover: #380823;
+  --color-surface-selected: #420825;
+
+  /* 文本 */
+  --color-on-surface: #ffc8e0;
+  --color-on-surface-variant: #ffa0d0;
+  --color-text-primary: #ffc8e0;
+  --color-text-secondary: #ffd8f0;
+  --color-text-tertiary: #cc70a8;
+
+  /* 品牌色 */
+  --color-primary: #e04090;
+  --color-on-primary: #1a0410;
+  --color-primary-container: #6f1240;
+  --color-primary-fixed: #ea7db4;
+  --color-primary-fixed-dim: #e45da1;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #e3539b;
+  --color-text-accent: #ec8abb;
+
+  /* 辅色 */
+  --color-secondary: #4a1430;
+  --color-secondary-container: #240818;
+  --color-tertiary: #d22222;
+  --color-tertiary-container: #560e0e;
+
+  /* 边框 */
+  --color-outline: #924772;
+  --color-outline-variant: #4a1430;
+  --color-border: #4a1430;
+  --color-border-focus: #e04090;
+  --color-border-separator: #390825;
+
+  /* 状态色 */
+  --color-error: #d02050;
+  --color-error-container: #3e0917;
+  --color-on-error-container: #f1a6ba;
+  --color-success: #79c579;
+  --color-success-container: #163416;
+  --color-info: #799fc5;
+  --color-info-container: #162534;
+  --color-warning: #d7bf76;
+  --color-warning-container: #382e12;
+
+  /* 反转 */
+  --color-inverse-surface: #ffc8e0;
+  --color-inverse-on-surface: #1a0410;
+  --color-inverse-primary: #f0a3c9;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffc8e0db;
+  --color-text-primary-a82: #ffc8e0e5;
+  --color-text-primary-a88: #ffc8e0f2;
+  --color-text-secondary-a68: #cc70a8c2;
+  --color-text-secondary-a72: #cc70a8cc;
+  --color-surface-hover-a34: #38082357;
+  --color-surface-hover-a54: #3808238a;
+  --color-outline-a72: #924772cc;
+  --color-outline-a78: #924772db;
+  --color-outline-a92: #924772eb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e0409040, 0 0 0 4px #e040901f;
+  --shadow-error-ring: 0 0 0 1px #d020504c, 0 0 0 4px #d0205026;
+  --shadow-button-primary: 0 8px 24px #e040904c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e0409033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #ad1c64);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #e4589e, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92477280;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #240818e5;
+  --color-sidebar-search-border: #92477266;
+  --color-sidebar-item-hover: #390825e5;
+  --color-sidebar-item-active: #390825eb;
+  --color-sidebar-item-active-border: #e0409029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a04109e;
+  --color-surface-glass: #240818eb;
+  --color-surface-glass-border: #2c0c1c4c;
+  --color-surface-info: #380823;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #340c20;
+
+  /* 代码语法（色相: ring 330° 偏移 +20°）*/
+  --color-code-bg: #390825;
+  --color-code-fg: #ffc8e0;
+  --color-code-comment: #8b3168;
+  --color-code-keyword: #e04090;
+  --color-code-string: #75b56f;
+  --color-code-function: #6f6fb5;
+  --color-code-number: #6faab5;
+  --color-code-type: #8cb56f;
+  --color-code-property: #feeff9;
+  --color-code-parameter: #c25496;
+  --color-code-punctuation: #ae3e82;
+  --color-code-inserted: #81db27;
+  --color-code-deleted: #d02050;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffc8e0;
+  --color-diff-syntax-comment: #8b3168;
+  --color-diff-syntax-string: #75b56f;
+  --color-diff-syntax-number: #6faab5;
+  --color-diff-syntax-regexp: #feeff9;
+  --color-diff-syntax-keyword: #e04090;
+  --color-diff-syntax-variable: #cc70a8;
+  --color-diff-syntax-parameter: #8b3168;
+  --color-diff-syntax-property: #feeff9;
+  --color-diff-syntax-function: #6f6fb5;
+  --color-diff-syntax-type: #8cb56f;
+  --color-diff-syntax-punctuation: #8b3168;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #90c38b;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d02050;
+  --color-diff-highlight-bg: #cd1878;
+  --color-diff-highlight-gutter: #a81362;
+  --color-diff-title-bg: #380823;
+  --color-diff-title-color: #cc70a8;
+  --color-diff-title-border: #4a1430;
+
+  /* 终端 */
+  --color-terminal-header: #390825;
+  --color-terminal-bg: #1a0410;
+  --color-terminal-border: #390825;
+  --color-terminal-fg: #ffc8e0;
+  --color-terminal-muted: #cc70a8;
+  --color-terminal-accent: #75b56f;
+  --color-terminal-danger: #d02050;
+  --color-terminal-warning: #e04090;
+
+  /* Inspector */
+  --color-inspector-surface: #2b001b;
+  --color-inspector-panel: #390825;
+  --color-inspector-chip: #2a0a1c;
+  --color-inspector-border: #4a1430;
+  --color-inspector-accent: #e04090;
+  --color-inspector-accent-hover: #e3539b;
+  --color-inspector-accent-secondary: #6f6fb5;
+  --color-inspector-text: #ffc8e0;
+  --color-inspector-heading: #ffc8e0;
+  --color-inspector-muted: #cc70a8;
+  --color-inspector-muted-strong: #ffd8f0;
+  --color-inspector-success: #62ab5b;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d02050;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #a40f5a;
+  --color-inspector-danger-border: #480b1b;
+  --color-inspector-capacity: #924772;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a0a1c;
+  --color-activity-heat-1: #760e42;
+  --color-activity-heat-2: #e33394;
+  --color-activity-heat-3: #6f1240;
+  --color-activity-heat-4: #e04090;
+  --color-activity-cell-border: #92477252;
+  --color-activity-cell-border-hover: #e040908c;
+  --color-activity-cell-border-active: #ffc8e0;
+  --color-activity-tooltip-surface: #300c20;
+  --color-activity-tooltip-border: #92477233;
+  --color-activity-tooltip-text: #ffc8e0;
+  --color-activity-tooltip-muted: #feeff9;
+
+  /* Memory/Goal */
+  --color-memory-accent: #924772;
+  --color-memory-surface: #2a0a1c;
+  --color-memory-border: #4a1430;
+  --color-memory-icon-bg: #390825;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e04090;
+  --color-switch-thumb: #1a0410;
+  --color-model-option-selected-bg: #390825;
+  --color-model-option-selected-border: #e0409033;
+
+  /* 其他 */
+  --color-window-close-hover: #d02050;
+  --color-selection-bg: #e040904c;
+  --color-selection-fg: #ffc8e0;
+  --color-chat-navigation-target: #e040901a;
+}
+

--- a/desktop/src/theme/custom/pearl-white-dark.css
+++ b/desktop/src/theme/custom/pearl-white-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="pearl-white"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a0806;
+  --color-on-background: #ffe8d4;
+  --color-surface: #240c0a;
+  --color-surface-dim: #1a0806;
+  --color-surface-bright: #3a1612;
+  --color-surface-container-lowest: #2a0e0c;
+  --color-surface-container-low: #340f0f;
+  --color-surface-container: #301210;
+  --color-surface-container-high: #3a1612;
+  --color-surface-container-highest: #4a1a16;
+  --color-surface-variant: #1d0707;
+  --color-surface-sidebar: #100402;
+  --color-surface-hover: #311010;
+  --color-surface-selected: #391010;
+
+  /* 文本 */
+  --color-on-surface: #ffe8d4;
+  --color-on-surface-variant: #ffd8c0;
+  --color-text-primary: #ffe8d4;
+  --color-text-secondary: #fff0e8;
+  --color-text-tertiary: #cc9070;
+
+  /* 品牌色 */
+  --color-primary: #e87858;
+  --color-on-primary: #1a0806;
+  --color-primary-container: #7e2911;
+  --color-primary-fixed: #f1b09e;
+  --color-primary-fixed-dim: #ec9379;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #eb8a6e;
+  --color-text-accent: #f3bcac;
+
+  /* 辅色 */
+  --color-secondary: #4a1a16;
+  --color-secondary-container: #240c0a;
+  --color-tertiary: #e2b02d;
+  --color-tertiary-container: #624a0d;
+
+  /* 边框 */
+  --color-outline: #925b48;
+  --color-outline-variant: #4a1a16;
+  --color-border: #4a1a16;
+  --color-border-focus: #e87858;
+  --color-border-separator: #340f0f;
+
+  /* 状态色 */
+  --color-error: #d03828;
+  --color-error-container: #3e100c;
+  --color-on-error-container: #f0bab4;
+  --color-success: #7fc87f;
+  --color-success-container: #183718;
+  --color-info: #7fa3c8;
+  --color-info-container: #182737;
+  --color-warning: #d9c27d;
+  --color-warning-container: #3c3214;
+
+  /* 反转 */
+  --color-inverse-surface: #ffe8d4;
+  --color-inverse-on-surface: #1a0806;
+  --color-inverse-primary: #f7d2c8;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffe8d4db;
+  --color-text-primary-a82: #ffe8d4e5;
+  --color-text-primary-a88: #ffe8d4f2;
+  --color-text-secondary-a68: #cc9070c2;
+  --color-text-secondary-a72: #cc9070cc;
+  --color-surface-hover-a34: #31101057;
+  --color-surface-hover-a54: #3110108a;
+  --color-outline-a72: #925b48cc;
+  --color-outline-a78: #925b48db;
+  --color-outline-a92: #925b48eb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8785840, 0 0 0 4px #e878581f;
+  --shadow-error-ring: 0 0 0 1px #d038284c, 0 0 0 4px #d0382826;
+  --shadow-button-primary: 0 8px 24px #e878584c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8785833, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #c4401b);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #eb8e74, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #925b4880;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #240c0ae5;
+  --color-sidebar-search-border: #925b4866;
+  --color-sidebar-item-hover: #340f0fe5;
+  --color-sidebar-item-active: #340f0feb;
+  --color-sidebar-item-active-border: #e8785829;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a08069e;
+  --color-surface-glass: #240c0aeb;
+  --color-surface-glass-border: #2c0f0d4c;
+  --color-surface-info: #311010;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #341210;
+
+  /* 代码语法（色相: ring 13° 偏移 +20°）*/
+  --color-code-bg: #340f0f;
+  --color-code-fg: #ffe8d4;
+  --color-code-comment: #8b5131;
+  --color-code-keyword: #e87858;
+  --color-code-string: #79ba73;
+  --color-code-function: #7373ba;
+  --color-code-number: #73aeba;
+  --color-code-type: #90ba73;
+  --color-code-property: #ffffff;
+  --color-code-parameter: #c27a54;
+  --color-code-punctuation: #ae653e;
+  --color-code-inserted: #3be461;
+  --color-code-deleted: #d03828;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffe8d4;
+  --color-diff-syntax-comment: #8b5131;
+  --color-diff-syntax-string: #79ba73;
+  --color-diff-syntax-number: #73aeba;
+  --color-diff-syntax-regexp: #ffffff;
+  --color-diff-syntax-keyword: #e87858;
+  --color-diff-syntax-variable: #cc9070;
+  --color-diff-syntax-parameter: #8b5131;
+  --color-diff-syntax-property: #ffffff;
+  --color-diff-syntax-function: #7373ba;
+  --color-diff-syntax-type: #90ba73;
+  --color-diff-syntax-punctuation: #8b5131;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #95c891;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d03828;
+  --color-diff-highlight-bg: #d8422f;
+  --color-diff-highlight-gutter: #b53222;
+  --color-diff-title-bg: #311010;
+  --color-diff-title-color: #cc9070;
+  --color-diff-title-border: #4a1a16;
+
+  /* 终端 */
+  --color-terminal-header: #340f0f;
+  --color-terminal-bg: #1a0806;
+  --color-terminal-border: #340f0f;
+  --color-terminal-fg: #ffe8d4;
+  --color-terminal-muted: #cc9070;
+  --color-terminal-accent: #79ba73;
+  --color-terminal-danger: #d03828;
+  --color-terminal-warning: #e87858;
+
+  /* Inspector */
+  --color-inspector-surface: #1c0800;
+  --color-inspector-panel: #340f0f;
+  --color-inspector-chip: #2a0e0c;
+  --color-inspector-border: #4a1a16;
+  --color-inspector-accent: #e87858;
+  --color-inspector-accent-hover: #eb8a6e;
+  --color-inspector-accent-secondary: #7373ba;
+  --color-inspector-text: #ffe8d4;
+  --color-inspector-heading: #ffe8d4;
+  --color-inspector-muted: #cc9070;
+  --color-inspector-muted-strong: #fff0e8;
+  --color-inspector-success: #65b05e;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d03828;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #8e221a;
+  --color-inspector-danger-border: #48130e;
+  --color-inspector-capacity: #925b48;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a0e0c;
+  --color-activity-heat-1: #85231c;
+  --color-activity-heat-2: #e38274;
+  --color-activity-heat-3: #7e2911;
+  --color-activity-heat-4: #e87858;
+  --color-activity-cell-border: #925b4852;
+  --color-activity-cell-border-hover: #e878588c;
+  --color-activity-cell-border-active: #ffe8d4;
+  --color-activity-tooltip-surface: #301210;
+  --color-activity-tooltip-border: #925b4833;
+  --color-activity-tooltip-text: #ffe8d4;
+  --color-activity-tooltip-muted: #ffffff;
+
+  /* Memory/Goal */
+  --color-memory-accent: #925b48;
+  --color-memory-surface: #2a0e0c;
+  --color-memory-border: #4a1a16;
+  --color-memory-icon-bg: #340f0f;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e87858;
+  --color-switch-thumb: #1a0806;
+  --color-model-option-selected-bg: #340f0f;
+  --color-model-option-selected-border: #e8785833;
+
+  /* 其他 */
+  --color-window-close-hover: #d03828;
+  --color-selection-bg: #e878584c;
+  --color-selection-fg: #ffe8d4;
+  --color-chat-navigation-target: #e878581a;
+}
+

--- a/desktop/src/theme/custom/plum-bruise-dark.css
+++ b/desktop/src/theme/custom/plum-bruise-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="plum-bruise"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a020c;
+  --color-on-background: #ffc8e0;
+  --color-surface: #240614;
+  --color-surface-dim: #1a020c;
+  --color-surface-bright: #3a0c24;
+  --color-surface-container-lowest: #2a0818;
+  --color-surface-container-low: #36081a;
+  --color-surface-container: #300a1c;
+  --color-surface-container-high: #3a0c24;
+  --color-surface-container-highest: #4a102c;
+  --color-surface-variant: #2c000e;
+  --color-surface-sidebar: #100106;
+  --color-surface-hover: #36081b;
+  --color-surface-selected: #3d0722;
+
+  /* 文本 */
+  --color-on-surface: #ffc8e0;
+  --color-on-surface-variant: #ffa0d0;
+  --color-text-primary: #ffc8e0;
+  --color-text-secondary: #ffd8f0;
+  --color-text-tertiary: #cc68a0;
+
+  /* 品牌色 */
+  --color-primary: #e03080;
+  --color-on-primary: #1a020c;
+  --color-primary-container: #6a0f39;
+  --color-primary-fixed: #e86ba4;
+  --color-primary-fixed-dim: #e44c91;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #e2428b;
+  --color-text-accent: #ea76ab;
+
+  /* 辅色 */
+  --color-secondary: #4a102c;
+  --color-secondary-container: #240614;
+  --color-tertiary: #c9241e;
+  --color-tertiary-container: #520f0c;
+
+  /* 边框 */
+  --color-outline: #92406c;
+  --color-outline-variant: #4a102c;
+  --color-border: #4a102c;
+  --color-border-focus: #e03080;
+  --color-border-separator: #36081a;
+
+  /* 状态色 */
+  --color-error: #d02060;
+  --color-error-container: #3e091c;
+  --color-on-error-container: #f1a6c1;
+  --color-success: #78c578;
+  --color-success-container: #153115;
+  --color-info: #789fc5;
+  --color-info-container: #152231;
+  --color-warning: #d7bf76;
+  --color-warning-container: #342b11;
+
+  /* 反转 */
+  --color-inverse-surface: #ffc8e0;
+  --color-inverse-on-surface: #1a020c;
+  --color-inverse-primary: #ee8eba;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffc8e0db;
+  --color-text-primary-a82: #ffc8e0e5;
+  --color-text-primary-a88: #ffc8e0f2;
+  --color-text-secondary-a68: #cc68a0c2;
+  --color-text-secondary-a72: #cc68a0cc;
+  --color-surface-hover-a34: #36081b57;
+  --color-surface-hover-a54: #36081b8a;
+  --color-outline-a72: #92406ccc;
+  --color-outline-a78: #92406cdb;
+  --color-outline-a92: #92406ceb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e0308040, 0 0 0 4px #e030801f;
+  --shadow-error-ring: 0 0 0 1px #d020604c, 0 0 0 4px #d0206026;
+  --shadow-button-primary: 0 8px 24px #e030804c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e0308033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #a51858);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #e3478e, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92406c80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #240614e5;
+  --color-sidebar-search-border: #92406c66;
+  --color-sidebar-item-hover: #36081ae5;
+  --color-sidebar-item-active: #36081aeb;
+  --color-sidebar-item-active-border: #e0308029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a020c9e;
+  --color-surface-glass: #240614eb;
+  --color-surface-glass-border: #2c091a4c;
+  --color-surface-info: #36081b;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #340a1c;
+
+  /* 代码语法（色相: ring 333° 偏移 +20°）*/
+  --color-code-bg: #36081a;
+  --color-code-fg: #ffc8e0;
+  --color-code-comment: #8a2e61;
+  --color-code-keyword: #e03080;
+  --color-code-string: #74b66e;
+  --color-code-function: #6e6eb6;
+  --color-code-number: #6eaab6;
+  --color-code-type: #8cb66e;
+  --color-code-property: #feeff9;
+  --color-code-parameter: #c24c8e;
+  --color-code-punctuation: #ac3a7a;
+  --color-code-inserted: #72d41f;
+  --color-code-deleted: #d02060;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffc8e0;
+  --color-diff-syntax-comment: #8a2e61;
+  --color-diff-syntax-string: #74b66e;
+  --color-diff-syntax-number: #6eaab6;
+  --color-diff-syntax-regexp: #feeff9;
+  --color-diff-syntax-keyword: #e03080;
+  --color-diff-syntax-variable: #cc68a0;
+  --color-diff-syntax-parameter: #8a2e61;
+  --color-diff-syntax-property: #feeff9;
+  --color-diff-syntax-function: #6e6eb6;
+  --color-diff-syntax-type: #8cb66e;
+  --color-diff-syntax-punctuation: #8a2e61;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #8fc48b;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d02060;
+  --color-diff-highlight-bg: #db0e63;
+  --color-diff-highlight-gutter: #b30b51;
+  --color-diff-title-bg: #36081b;
+  --color-diff-title-color: #cc68a0;
+  --color-diff-title-border: #4a102c;
+
+  /* 终端 */
+  --color-terminal-header: #36081a;
+  --color-terminal-bg: #1a020c;
+  --color-terminal-border: #36081a;
+  --color-terminal-fg: #ffc8e0;
+  --color-terminal-muted: #cc68a0;
+  --color-terminal-accent: #74b66e;
+  --color-terminal-danger: #d02060;
+  --color-terminal-warning: #e03080;
+
+  /* Inspector */
+  --color-inspector-surface: #29000d;
+  --color-inspector-panel: #36081a;
+  --color-inspector-chip: #2a0818;
+  --color-inspector-border: #4a102c;
+  --color-inspector-accent: #e03080;
+  --color-inspector-accent-hover: #e2428b;
+  --color-inspector-accent-secondary: #6e6eb6;
+  --color-inspector-text: #ffc8e0;
+  --color-inspector-heading: #ffc8e0;
+  --color-inspector-muted: #cc68a0;
+  --color-inspector-muted-strong: #ffd8f0;
+  --color-inspector-success: #61ac5a;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d02060;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #c6075f;
+  --color-inspector-danger-border: #480b21;
+  --color-inspector-capacity: #92406c;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a0818;
+  --color-activity-heat-1: #7d0838;
+  --color-activity-heat-2: #ef2475;
+  --color-activity-heat-3: #6a0f39;
+  --color-activity-heat-4: #e03080;
+  --color-activity-cell-border: #92406c52;
+  --color-activity-cell-border-hover: #e030808c;
+  --color-activity-cell-border-active: #ffc8e0;
+  --color-activity-tooltip-surface: #300a1c;
+  --color-activity-tooltip-border: #92406c33;
+  --color-activity-tooltip-text: #ffc8e0;
+  --color-activity-tooltip-muted: #feeff9;
+
+  /* Memory/Goal */
+  --color-memory-accent: #92406c;
+  --color-memory-surface: #2a0818;
+  --color-memory-border: #4a102c;
+  --color-memory-icon-bg: #36081a;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e03080;
+  --color-switch-thumb: #1a020c;
+  --color-model-option-selected-bg: #36081a;
+  --color-model-option-selected-border: #e0308033;
+
+  /* 其他 */
+  --color-window-close-hover: #d02060;
+  --color-selection-bg: #e030804c;
+  --color-selection-fg: #ffc8e0;
+  --color-chat-navigation-target: #e030801a;
+}
+

--- a/desktop/src/theme/custom/rose-quartz-dark.css
+++ b/desktop/src/theme/custom/rose-quartz-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="rose-quartz"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a020a;
+  --color-on-background: #ffd0e0;
+  --color-surface: #24060e;
+  --color-surface-dim: #1a020a;
+  --color-surface-bright: #3a0c18;
+  --color-surface-container-lowest: #2a0810;
+  --color-surface-container-low: #360812;
+  --color-surface-container: #300a14;
+  --color-surface-container-high: #3a0c18;
+  --color-surface-container-highest: #4a101e;
+  --color-surface-variant: #2b000d;
+  --color-surface-sidebar: #100104;
+  --color-surface-hover: #350810;
+  --color-surface-selected: #3a0811;
+
+  /* 文本 */
+  --color-on-surface: #ffd0e0;
+  --color-on-surface-variant: #ffb0cc;
+  --color-text-primary: #ffd0e0;
+  --color-text-secondary: #ffe0ee;
+  --color-text-tertiary: #cc6890;
+
+  /* 品牌色 */
+  --color-primary: #e82860;
+  --color-on-primary: #1a020a;
+  --color-primary-container: #6e0b28;
+  --color-primary-fixed: #ee658d;
+  --color-primary-fixed-dim: #eb4575;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #ea3b6e;
+  --color-text-accent: #ef7196;
+
+  /* 辅色 */
+  --color-secondary: #4a101e;
+  --color-secondary-container: #24060e;
+  --color-tertiary: #cf3c17;
+  --color-tertiary-container: #551909;
+
+  /* 边框 */
+  --color-outline: #92405d;
+  --color-outline-variant: #4a101e;
+  --color-border: #4a101e;
+  --color-border-focus: #e82860;
+  --color-border-separator: #360812;
+
+  /* 状态色 */
+  --color-error: #d01230;
+  --color-error-container: #3e050e;
+  --color-on-error-container: #f48b9b;
+  --color-success: #7cc67c;
+  --color-success-container: #153115;
+  --color-info: #7ca1c6;
+  --color-info-container: #152231;
+  --color-warning: #d8c07a;
+  --color-warning-container: #342b11;
+
+  /* 反转 */
+  --color-inverse-surface: #ffd0e0;
+  --color-inverse-on-surface: #1a020a;
+  --color-inverse-primary: #f28aa8;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffd0e0db;
+  --color-text-primary-a82: #ffd0e0e5;
+  --color-text-primary-a88: #ffd0e0f2;
+  --color-text-secondary-a68: #cc6890c2;
+  --color-text-secondary-a72: #cc6890cc;
+  --color-surface-hover-a34: #35081057;
+  --color-surface-hover-a54: #3508108a;
+  --color-outline-a72: #92405dcc;
+  --color-outline-a78: #92405ddb;
+  --color-outline-a92: #92405deb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8286040, 0 0 0 4px #e828601f;
+  --shadow-error-ring: 0 0 0 1px #d012304c, 0 0 0 4px #d0123026;
+  --shadow-button-primary: 0 8px 24px #e828604c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8286033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #ab123f);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #ea4072, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92405d80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #24060ee5;
+  --color-sidebar-search-border: #92405d66;
+  --color-sidebar-item-hover: #360812e5;
+  --color-sidebar-item-active: #360812eb;
+  --color-sidebar-item-active-border: #e8286029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a020a9e;
+  --color-surface-glass: #24060eeb;
+  --color-surface-glass-border: #2c09124c;
+  --color-surface-info: #350810;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #340a14;
+
+  /* 代码语法（色相: ring 342° 偏移 +20°）*/
+  --color-code-bg: #360812;
+  --color-code-fg: #ffd0e0;
+  --color-code-comment: #8a2e53;
+  --color-code-keyword: #e82860;
+  --color-code-string: #74bb6e;
+  --color-code-function: #6e6ebb;
+  --color-code-number: #6eaebb;
+  --color-code-type: #8ebb6e;
+  --color-code-property: #fff7fb;
+  --color-code-parameter: #c24c7b;
+  --color-code-punctuation: #ac3a68;
+  --color-code-inserted: #51db18;
+  --color-code-deleted: #d01230;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffd0e0;
+  --color-diff-syntax-comment: #8a2e53;
+  --color-diff-syntax-string: #74bb6e;
+  --color-diff-syntax-number: #6eaebb;
+  --color-diff-syntax-regexp: #fff7fb;
+  --color-diff-syntax-keyword: #e82860;
+  --color-diff-syntax-variable: #cc6890;
+  --color-diff-syntax-parameter: #8a2e53;
+  --color-diff-syntax-property: #fff7fb;
+  --color-diff-syntax-function: #6e6ebb;
+  --color-diff-syntax-type: #8ebb6e;
+  --color-diff-syntax-punctuation: #8a2e53;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #91c98c;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d01230;
+  --color-diff-highlight-bg: #ec075b;
+  --color-diff-highlight-gutter: #c1054a;
+  --color-diff-title-bg: #350810;
+  --color-diff-title-color: #cc6890;
+  --color-diff-title-border: #4a101e;
+
+  /* 终端 */
+  --color-terminal-header: #360812;
+  --color-terminal-bg: #1a020a;
+  --color-terminal-border: #360812;
+  --color-terminal-fg: #ffd0e0;
+  --color-terminal-muted: #cc6890;
+  --color-terminal-accent: #74bb6e;
+  --color-terminal-danger: #d01230;
+  --color-terminal-warning: #e82860;
+
+  /* Inspector */
+  --color-inspector-surface: #28000c;
+  --color-inspector-panel: #360812;
+  --color-inspector-chip: #2a0810;
+  --color-inspector-border: #4a101e;
+  --color-inspector-accent: #e82860;
+  --color-inspector-accent-hover: #ea3b6e;
+  --color-inspector-accent-secondary: #6e6ebb;
+  --color-inspector-text: #ffd0e0;
+  --color-inspector-heading: #ffd0e0;
+  --color-inspector-muted: #cc6890;
+  --color-inspector-muted-strong: #ffe0ee;
+  --color-inspector-success: #60b159;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d01230;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #be073f;
+  --color-inspector-danger-border: #480610;
+  --color-inspector-capacity: #92405d;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a0810;
+  --color-activity-heat-1: #81092e;
+  --color-activity-heat-2: #f4266d;
+  --color-activity-heat-3: #6e0b28;
+  --color-activity-heat-4: #e82860;
+  --color-activity-cell-border: #92405d52;
+  --color-activity-cell-border-hover: #e828608c;
+  --color-activity-cell-border-active: #ffd0e0;
+  --color-activity-tooltip-surface: #300a14;
+  --color-activity-tooltip-border: #92405d33;
+  --color-activity-tooltip-text: #ffd0e0;
+  --color-activity-tooltip-muted: #fff7fb;
+
+  /* Memory/Goal */
+  --color-memory-accent: #92405d;
+  --color-memory-surface: #2a0810;
+  --color-memory-border: #4a101e;
+  --color-memory-icon-bg: #360812;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e82860;
+  --color-switch-thumb: #1a020a;
+  --color-model-option-selected-bg: #360812;
+  --color-model-option-selected-border: #e8286033;
+
+  /* 其他 */
+  --color-window-close-hover: #d01230;
+  --color-selection-bg: #e828604c;
+  --color-selection-fg: #ffd0e0;
+  --color-chat-navigation-target: #e828601a;
+}
+

--- a/desktop/src/theme/custom/spring-peach-dark.css
+++ b/desktop/src/theme/custom/spring-peach-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="spring-peach"] {
+  color-scheme: light;
+
+  /* Surface 层级 */
+  --color-background: #fcf6f2;
+  --color-on-background: #4a3a30;
+  --color-surface: #faf2ee;
+  --color-surface-dim: #fcf6f2;
+  --color-surface-bright: #f0e0d4;
+  --color-surface-container-lowest: #fcf6f2;
+  --color-surface-container-low: #e0e0e0;
+  --color-surface-container: #ecdcd0;
+  --color-surface-container-high: #f0e0d4;
+  --color-surface-container-highest: #faf2ee;
+  --color-surface-variant: #eaeaea;
+  --color-surface-sidebar: #f6ece4;
+  --color-surface-hover: #e4e4e4;
+  --color-surface-selected: #d1d1d1;
+
+  /* 文本 */
+  --color-on-surface: #4a3a30;
+  --color-on-surface-variant: #5a4840;
+  --color-text-primary: #4a3a30;
+  --color-text-secondary: #4a3a30;
+  --color-text-tertiary: #8a7868;
+
+  /* 品牌色 */
+  --color-primary: #e0b0a0;
+  --color-on-primary: #fcf6f2;
+  --color-primary-container: #82402a;
+  --color-primary-fixed: #f7ece8;
+  --color-primary-fixed-dim: #ebccc2;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #e7c3b7;
+  --color-text-accent: #fcf8f6;
+
+  /* 辅色 */
+  --color-secondary: #faf2ee;
+  --color-secondary-container: #faf2ee;
+  --color-tertiary: #d1ba74;
+  --color-tertiary-container: #655421;
+
+  /* 边框 */
+  --color-outline: #af9e8c;
+  --color-outline-variant: #dcccb8;
+  --color-border: #dcccb8;
+  --color-border-focus: #e0b0a0;
+  --color-border-separator: #e0e0e0;
+
+  /* 状态色 */
+  --color-error: #c84038;
+  --color-error-container: #3c1310;
+  --color-on-error-container: #eec6c4;
+  --color-success: #53cd53;
+  --color-success-container: #c9e8c9;
+  --color-info: #5390cd;
+  --color-info-container: #c9d8e8;
+  --color-warning: #e0bc50;
+  --color-warning-container: #ebe2c5;
+
+  /* 反转 */
+  --color-inverse-surface: #4a3a30;
+  --color-inverse-on-surface: #fcf6f2;
+  --color-inverse-primary: #ffffff;
+
+  /* 透明度 */
+  --color-text-primary-a78: #4a3a30c8;
+  --color-text-primary-a82: #4a3a30d3;
+  --color-text-primary-a88: #4a3a30e2;
+  --color-text-secondary-a68: #8a7868af;
+  --color-text-secondary-a72: #8a7868b9;
+  --color-surface-hover-a34: #e4e4e457;
+  --color-surface-hover-a54: #e4e4e48a;
+  --color-outline-a72: #af9e8cb9;
+  --color-outline-a78: #af9e8cc8;
+  --color-outline-a92: #af9e8ceb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e0b0a040, 0 0 0 4px #e0b0a01f;
+  --shadow-error-ring: 0 0 0 1px #c840384c, 0 0 0 4px #c8403826;
+  --shadow-button-primary: 0 8px 24px #e0b0a04c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e0b0a033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #c36749);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #e9c8bc, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #af9e8c80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #faf2eed3;
+  --color-sidebar-search-border: #af9e8c66;
+  --color-sidebar-item-hover: #e0e0e0d3;
+  --color-sidebar-item-active: #e0e0e0eb;
+  --color-sidebar-item-active-border: #e0b0a029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #fcf6f29e;
+  --color-surface-glass: #faf2eeeb;
+  --color-surface-glass-border: #a27d504c;
+  --color-surface-info: #e4e4e4;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #f2e8e0;
+
+  /* 代码语法（色相: ring 15° 偏移 +20°）*/
+  --color-code-bg: #e0e0e0;
+  --color-code-fg: #4a3a30;
+  --color-code-comment: #52483e;
+  --color-code-keyword: #e0b0a0;
+  --color-code-string: #5cb254;
+  --color-code-function: #5454b2;
+  --color-code-number: #54a2b2;
+  --color-code-type: #7bb254;
+  --color-code-property: #4d3c32;
+  --color-code-parameter: #79695b;
+  --color-code-punctuation: #67594d;
+  --color-code-inserted: #83d697;
+  --color-code-deleted: #c84038;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #4a3a30;
+  --color-diff-syntax-comment: #52483e;
+  --color-diff-syntax-string: #5cb254;
+  --color-diff-syntax-number: #54a2b2;
+  --color-diff-syntax-regexp: #4d3c32;
+  --color-diff-syntax-keyword: #e0b0a0;
+  --color-diff-syntax-variable: #8a7868;
+  --color-diff-syntax-parameter: #52483e;
+  --color-diff-syntax-property: #4d3c32;
+  --color-diff-syntax-function: #5454b2;
+  --color-diff-syntax-type: #7bb254;
+  --color-diff-syntax-punctuation: #52483e;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #e8f5e2;
+  --color-diff-added-word: #b8e4a8;
+  --color-diff-added-gutter: #d4edca;
+  --color-diff-added-text: #75be6f;
+  --color-diff-removed-bg: #fdecea;
+  --color-diff-removed-word: #f5b8b4;
+  --color-diff-removed-gutter: #f9d4d0;
+  --color-diff-removed-text: #c84038;
+  --color-diff-highlight-bg: #fff5d6;
+  --color-diff-highlight-gutter: #ffe081;
+  --color-diff-title-bg: #e4e4e4;
+  --color-diff-title-color: #8a7868;
+  --color-diff-title-border: #dcccb8;
+
+  /* 终端 */
+  --color-terminal-header: #e0e0e0;
+  --color-terminal-bg: #fcf6f2;
+  --color-terminal-border: #e0e0e0;
+  --color-terminal-fg: #4a3a30;
+  --color-terminal-muted: #8a7868;
+  --color-terminal-accent: #5cb254;
+  --color-terminal-danger: #c84038;
+  --color-terminal-warning: #e0b0a0;
+
+  /* Inspector */
+  --color-inspector-surface: #eaeaea;
+  --color-inspector-panel: #e0e0e0;
+  --color-inspector-chip: #fcf6f2;
+  --color-inspector-border: #dcccb8;
+  --color-inspector-accent: #e0b0a0;
+  --color-inspector-accent-hover: #e7c3b7;
+  --color-inspector-accent-secondary: #5454b2;
+  --color-inspector-text: #4a3a30;
+  --color-inspector-heading: #4a3a30;
+  --color-inspector-muted: #8a7868;
+  --color-inspector-muted-strong: #4a3a30;
+  --color-inspector-success: #50a249;
+  --color-inspector-success-bg: #e8f5e2;
+  --color-inspector-danger: #c84038;
+  --color-inspector-danger-bg: #fdecea;
+  --color-inspector-danger-surface: #93fdff;
+  --color-inspector-danger-border: #461613;
+  --color-inspector-capacity: #af9e8c;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #fcf6f2;
+  --color-activity-heat-1: #e6e6e6;
+  --color-activity-heat-2: #d9d9d9;
+  --color-activity-heat-3: #82402a;
+  --color-activity-heat-4: #e0b0a0;
+  --color-activity-cell-border: #af9e8c52;
+  --color-activity-cell-border-hover: #e0b0a08c;
+  --color-activity-cell-border-active: #4a3a30;
+  --color-activity-tooltip-surface: #ecdcd0;
+  --color-activity-tooltip-border: #af9e8c33;
+  --color-activity-tooltip-text: #4a3a30;
+  --color-activity-tooltip-muted: #4d3c32;
+
+  /* Memory/Goal */
+  --color-memory-accent: #af9e8c;
+  --color-memory-surface: #fcf6f2;
+  --color-memory-border: #dcccb8;
+  --color-memory-icon-bg: #e0e0e0;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e0b0a0;
+  --color-switch-thumb: #fcf6f2;
+  --color-model-option-selected-bg: #e0e0e0;
+  --color-model-option-selected-border: #e0b0a033;
+
+  /* 其他 */
+  --color-window-close-hover: #c84038;
+  --color-selection-bg: #e0b0a04c;
+  --color-selection-fg: #4a3a30;
+  --color-chat-navigation-target: #e0b0a01a;
+}
+

--- a/desktop/src/theme/custom/storm-indigo-dark.css
+++ b/desktop/src/theme/custom/storm-indigo-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="storm-indigo"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a0206;
+  --color-on-background: #ffc8d4;
+  --color-surface: #24060a;
+  --color-surface-dim: #1a0206;
+  --color-surface-bright: #3a0c14;
+  --color-surface-container-lowest: #2a080c;
+  --color-surface-container-low: #370808;
+  --color-surface-container: #300a10;
+  --color-surface-container-high: #3a0c14;
+  --color-surface-container-highest: #4a101a;
+  --color-surface-variant: #2e0000;
+  --color-surface-sidebar: #100002;
+  --color-surface-hover: #360808;
+  --color-surface-selected: #390811;
+
+  /* 文本 */
+  --color-on-surface: #ffc8d4;
+  --color-on-surface-variant: #ffa0b8;
+  --color-text-primary: #ffc8d4;
+  --color-text-secondary: #ffd8e4;
+  --color-text-tertiary: #cc7088;
+
+  /* 品牌色 */
+  --color-primary: #e83060;
+  --color-on-primary: #1a0206;
+  --color-primary-container: #710c26;
+  --color-primary-fixed: #ee6f90;
+  --color-primary-fixed-dim: #eb4e77;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #ea446f;
+  --color-text-accent: #f07b9a;
+
+  /* 辅色 */
+  --color-secondary: #4a101a;
+  --color-secondary-container: #24060a;
+  --color-tertiary: #d44418;
+  --color-tertiary-container: #571c0a;
+
+  /* 边框 */
+  --color-outline: #924556;
+  --color-outline-variant: #4a101a;
+  --color-border: #4a101a;
+  --color-border-focus: #e83060;
+  --color-border-separator: #370808;
+
+  /* 状态色 */
+  --color-error: #d01830;
+  --color-error-container: #3e070e;
+  --color-on-error-container: #f397a3;
+  --color-success: #78c578;
+  --color-success-container: #153115;
+  --color-info: #789fc5;
+  --color-info-container: #152231;
+  --color-warning: #d7bf76;
+  --color-warning-container: #342b11;
+
+  /* 反转 */
+  --color-inverse-surface: #ffc8d4;
+  --color-inverse-on-surface: #1a0206;
+  --color-inverse-primary: #f394ad;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffc8d4db;
+  --color-text-primary-a82: #ffc8d4e5;
+  --color-text-primary-a88: #ffc8d4f2;
+  --color-text-secondary-a68: #cc7088c2;
+  --color-text-secondary-a72: #cc7088cc;
+  --color-surface-hover-a34: #36080857;
+  --color-surface-hover-a54: #3608088a;
+  --color-outline-a72: #924556cc;
+  --color-outline-a78: #924556db;
+  --color-outline-a92: #924556eb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8306040, 0 0 0 4px #e830601f;
+  --shadow-error-ring: 0 0 0 1px #d018304c, 0 0 0 4px #d0183026;
+  --shadow-button-primary: 0 8px 24px #e830604c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8306033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #b0133c);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #ea4973, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92455680;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #24060ae5;
+  --color-sidebar-search-border: #92455666;
+  --color-sidebar-item-hover: #370808e5;
+  --color-sidebar-item-active: #370808eb;
+  --color-sidebar-item-active-border: #e8306029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a02069e;
+  --color-surface-glass: #24060aeb;
+  --color-surface-glass-border: #2c090f4c;
+  --color-surface-info: #360808;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #340a10;
+
+  /* 代码语法（色相: ring 344° 偏移 +20°）*/
+  --color-code-bg: #370808;
+  --color-code-fg: #ffc8d4;
+  --color-code-comment: #8b3149;
+  --color-code-keyword: #e83060;
+  --color-code-string: #71b96b;
+  --color-code-function: #6b6bb9;
+  --color-code-number: #6bacb9;
+  --color-code-type: #8bb96b;
+  --color-code-property: #feeff4;
+  --color-code-parameter: #c25470;
+  --color-code-punctuation: #ae3e5b;
+  --color-code-inserted: #4ee11a;
+  --color-code-deleted: #d01830;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffc8d4;
+  --color-diff-syntax-comment: #8b3149;
+  --color-diff-syntax-string: #71b96b;
+  --color-diff-syntax-number: #6bacb9;
+  --color-diff-syntax-regexp: #feeff4;
+  --color-diff-syntax-keyword: #e83060;
+  --color-diff-syntax-variable: #cc7088;
+  --color-diff-syntax-parameter: #8b3149;
+  --color-diff-syntax-property: #feeff4;
+  --color-diff-syntax-function: #6b6bb9;
+  --color-diff-syntax-type: #8bb96b;
+  --color-diff-syntax-punctuation: #8b3149;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #8dc788;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d01830;
+  --color-diff-highlight-bg: #e40d37;
+  --color-diff-highlight-gutter: #ba0a2d;
+  --color-diff-title-bg: #360808;
+  --color-diff-title-color: #cc7088;
+  --color-diff-title-border: #4a101a;
+
+  /* 终端 */
+  --color-terminal-header: #370808;
+  --color-terminal-bg: #1a0206;
+  --color-terminal-border: #370808;
+  --color-terminal-fg: #ffc8d4;
+  --color-terminal-muted: #cc7088;
+  --color-terminal-accent: #71b96b;
+  --color-terminal-danger: #d01830;
+  --color-terminal-warning: #e83060;
+
+  /* Inspector */
+  --color-inspector-surface: #2b0000;
+  --color-inspector-panel: #370808;
+  --color-inspector-chip: #2a080c;
+  --color-inspector-border: #4a101a;
+  --color-inspector-accent: #e83060;
+  --color-inspector-accent-hover: #ea446f;
+  --color-inspector-accent-secondary: #6b6bb9;
+  --color-inspector-text: #ffc8d4;
+  --color-inspector-heading: #ffc8d4;
+  --color-inspector-muted: #cc7088;
+  --color-inspector-muted-strong: #ffd8e4;
+  --color-inspector-success: #5daf57;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d01830;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #c5072b;
+  --color-inspector-danger-border: #480810;
+  --color-inspector-capacity: #924556;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a080c;
+  --color-activity-heat-1: #87091c;
+  --color-activity-heat-2: #f0345a;
+  --color-activity-heat-3: #710c26;
+  --color-activity-heat-4: #e83060;
+  --color-activity-cell-border: #92455652;
+  --color-activity-cell-border-hover: #e830608c;
+  --color-activity-cell-border-active: #ffc8d4;
+  --color-activity-tooltip-surface: #300a10;
+  --color-activity-tooltip-border: #92455633;
+  --color-activity-tooltip-text: #ffc8d4;
+  --color-activity-tooltip-muted: #feeff4;
+
+  /* Memory/Goal */
+  --color-memory-accent: #924556;
+  --color-memory-surface: #2a080c;
+  --color-memory-border: #4a101a;
+  --color-memory-icon-bg: #370808;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e83060;
+  --color-switch-thumb: #1a0206;
+  --color-model-option-selected-bg: #370808;
+  --color-model-option-selected-border: #e8306033;
+
+  /* 其他 */
+  --color-window-close-hover: #d01830;
+  --color-selection-bg: #e830604c;
+  --color-selection-fg: #ffc8d4;
+  --color-chat-navigation-target: #e830601a;
+}
+

--- a/desktop/src/theme/custom/twilight-violet-dark.css
+++ b/desktop/src/theme/custom/twilight-violet-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="twilight-violet"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #14041a;
+  --color-on-background: #e0c8ff;
+  --color-surface: #1c0824;
+  --color-surface-dim: #14041a;
+  --color-surface-bright: #34103a;
+  --color-surface-container-lowest: #220a2a;
+  --color-surface-container-low: #2e0837;
+  --color-surface-container: #280c30;
+  --color-surface-container-high: #34103a;
+  --color-surface-container-highest: #44144a;
+  --color-surface-variant: #210032;
+  --color-surface-sidebar: #0c0210;
+  --color-surface-hover: #2d0836;
+  --color-surface-selected: #31083a;
+
+  /* 文本 */
+  --color-on-surface: #e0c8ff;
+  --color-on-surface-variant: #d0a0ff;
+  --color-text-primary: #e0c8ff;
+  --color-text-secondary: #e8d8ff;
+  --color-text-tertiary: #a870cc;
+
+  /* 品牌色 */
+  --color-primary: #8840e0;
+  --color-on-primary: #14041a;
+  --color-primary-container: #3c126f;
+  --color-primary-fixed: #ae7dea;
+  --color-primary-fixed-dim: #9a5de4;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #9453e3;
+  --color-text-accent: #b68aec;
+
+  /* 辅色 */
+  --color-secondary: #44144a;
+  --color-secondary-container: #1c0824;
+  --color-tertiary: #c922d2;
+  --color-tertiary-container: #530e56;
+
+  /* 边框 */
+  --color-outline: #7b4792;
+  --color-outline-variant: #44144a;
+  --color-border: #44144a;
+  --color-border-focus: #8840e0;
+  --color-border-separator: #2e0837;
+
+  /* 状态色 */
+  --color-error: #c03060;
+  --color-error-container: #390e1c;
+  --color-on-error-container: #eaadc1;
+  --color-success: #79c579;
+  --color-success-container: #163416;
+  --color-info: #799fc5;
+  --color-info-container: #162534;
+  --color-warning: #d7bf76;
+  --color-warning-container: #382e12;
+
+  /* 反转 */
+  --color-inverse-surface: #e0c8ff;
+  --color-inverse-on-surface: #14041a;
+  --color-inverse-primary: #c5a3f0;
+
+  /* 透明度 */
+  --color-text-primary-a78: #e0c8ffdb;
+  --color-text-primary-a82: #e0c8ffe5;
+  --color-text-primary-a88: #e0c8fff2;
+  --color-text-secondary-a68: #a870ccc2;
+  --color-text-secondary-a72: #a870cccc;
+  --color-surface-hover-a34: #2d083657;
+  --color-surface-hover-a54: #2d08368a;
+  --color-outline-a72: #7b4792cc;
+  --color-outline-a78: #7b4792db;
+  --color-outline-a92: #7b4792eb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #8840e040, 0 0 0 4px #8840e01f;
+  --shadow-error-ring: 0 0 0 1px #c030604c, 0 0 0 4px #c0306026;
+  --shadow-button-primary: 0 8px 24px #8840e04c;
+  --shadow-activity-cell-hover: 0 0 0 2px #8840e033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #5d1cad);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #9758e4, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #7b479280;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #1c0824e5;
+  --color-sidebar-search-border: #7b479266;
+  --color-sidebar-item-hover: #2e0837e5;
+  --color-sidebar-item-active: #2e0837eb;
+  --color-sidebar-item-active-border: #8840e029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #14041a9e;
+  --color-surface-glass: #1c0824eb;
+  --color-surface-glass-border: #280c2c4c;
+  --color-surface-info: #2d0836;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #2c0c30;
+
+  /* 代码语法（色相: ring 267° 偏移 -25°）*/
+  --color-code-bg: #2e0837;
+  --color-code-fg: #e0c8ff;
+  --color-code-comment: #68318b;
+  --color-code-keyword: #8840e0;
+  --color-code-string: #aab56f;
+  --color-code-function: #6fa4b5;
+  --color-code-number: #6fb58c;
+  --color-code-type: #b5aa6f;
+  --color-code-property: #f5effe;
+  --color-code-parameter: #9654c2;
+  --color-code-punctuation: #823eae;
+  --color-code-inserted: #db7727;
+  --color-code-deleted: #c03060;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #e0c8ff;
+  --color-diff-syntax-comment: #68318b;
+  --color-diff-syntax-string: #aab56f;
+  --color-diff-syntax-number: #6fb58c;
+  --color-diff-syntax-regexp: #f5effe;
+  --color-diff-syntax-keyword: #8840e0;
+  --color-diff-syntax-variable: #a870cc;
+  --color-diff-syntax-parameter: #68318b;
+  --color-diff-syntax-property: #f5effe;
+  --color-diff-syntax-function: #6fa4b5;
+  --color-diff-syntax-type: #b5aa6f;
+  --color-diff-syntax-punctuation: #68318b;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #bbc38b;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #c03060;
+  --color-diff-highlight-bg: #7a12a0;
+  --color-diff-highlight-gutter: #640e83;
+  --color-diff-title-bg: #2d0836;
+  --color-diff-title-color: #a870cc;
+  --color-diff-title-border: #44144a;
+
+  /* 终端 */
+  --color-terminal-header: #2e0837;
+  --color-terminal-bg: #14041a;
+  --color-terminal-border: #2e0837;
+  --color-terminal-fg: #e0c8ff;
+  --color-terminal-muted: #a870cc;
+  --color-terminal-accent: #aab56f;
+  --color-terminal-danger: #c03060;
+  --color-terminal-warning: #8840e0;
+
+  /* Inspector */
+  --color-inspector-surface: #1f002f;
+  --color-inspector-panel: #2e0837;
+  --color-inspector-chip: #220a2a;
+  --color-inspector-border: #44144a;
+  --color-inspector-accent: #8840e0;
+  --color-inspector-accent-hover: #9453e3;
+  --color-inspector-accent-secondary: #6fa4b5;
+  --color-inspector-text: #e0c8ff;
+  --color-inspector-heading: #e0c8ff;
+  --color-inspector-muted: #a870cc;
+  --color-inspector-muted-strong: #e8d8ff;
+  --color-inspector-success: #9eab5b;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #c03060;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #820e9f;
+  --color-inspector-danger-border: #431021;
+  --color-inspector-capacity: #7b4792;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #220a2a;
+  --color-activity-heat-1: #470867;
+  --color-activity-heat-2: #a717e2;
+  --color-activity-heat-3: #3c126f;
+  --color-activity-heat-4: #8840e0;
+  --color-activity-cell-border: #7b479252;
+  --color-activity-cell-border-hover: #8840e08c;
+  --color-activity-cell-border-active: #e0c8ff;
+  --color-activity-tooltip-surface: #280c30;
+  --color-activity-tooltip-border: #7b479233;
+  --color-activity-tooltip-text: #e0c8ff;
+  --color-activity-tooltip-muted: #f5effe;
+
+  /* Memory/Goal */
+  --color-memory-accent: #7b4792;
+  --color-memory-surface: #220a2a;
+  --color-memory-border: #44144a;
+  --color-memory-icon-bg: #2e0837;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #8840e0;
+  --color-switch-thumb: #14041a;
+  --color-model-option-selected-bg: #2e0837;
+  --color-model-option-selected-border: #8840e033;
+
+  /* 其他 */
+  --color-window-close-hover: #c03060;
+  --color-selection-bg: #8840e04c;
+  --color-selection-fg: #e0c8ff;
+  --color-chat-navigation-target: #8840e01a;
+}
+

--- a/desktop/src/theme/custom/velvet-crimson-dark.css
+++ b/desktop/src/theme/custom/velvet-crimson-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="velvet-crimson"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a0208;
+  --color-on-background: #ffd0dc;
+  --color-surface: #24060c;
+  --color-surface-dim: #1a0208;
+  --color-surface-bright: #3a0c16;
+  --color-surface-container-lowest: #2a080e;
+  --color-surface-container-low: #360811;
+  --color-surface-container: #300a12;
+  --color-surface-container-high: #3a0c16;
+  --color-surface-container-highest: #4a101c;
+  --color-surface-variant: #2a000d;
+  --color-surface-sidebar: #100004;
+  --color-surface-hover: #350810;
+  --color-surface-selected: #3a0811;
+
+  /* 文本 */
+  --color-on-surface: #ffd0dc;
+  --color-on-surface-variant: #ffb0c8;
+  --color-text-primary: #ffd0dc;
+  --color-text-secondary: #ffe0ec;
+  --color-text-tertiary: #cc6888;
+
+  /* 品牌色 */
+  --color-primary: #e82058;
+  --color-on-primary: #1a0208;
+  --color-primary-container: #6b0b26;
+  --color-primary-fixed: #ee5b84;
+  --color-primary-fixed-dim: #ea3c6d;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #e93366;
+  --color-text-accent: #ef678d;
+
+  /* 辅色 */
+  --color-secondary: #4a101c;
+  --color-secondary-container: #24060c;
+  --color-tertiary: #ca3c14;
+  --color-tertiary-container: #531808;
+
+  /* 边框 */
+  --color-outline: #924057;
+  --color-outline-variant: #4a101c;
+  --color-border: #4a101c;
+  --color-border-focus: #e82058;
+  --color-border-separator: #360811;
+
+  /* 状态色 */
+  --color-error: #d01028;
+  --color-error-container: #3e040c;
+  --color-on-error-container: #f58794;
+  --color-success: #7cc67c;
+  --color-success-container: #153115;
+  --color-info: #7ca1c6;
+  --color-info-container: #152231;
+  --color-warning: #d8c07a;
+  --color-warning-container: #342b11;
+
+  /* 反转 */
+  --color-inverse-surface: #ffd0dc;
+  --color-inverse-on-surface: #1a0208;
+  --color-inverse-primary: #f17f9f;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffd0dcdb;
+  --color-text-primary-a82: #ffd0dce5;
+  --color-text-primary-a88: #ffd0dcf2;
+  --color-text-secondary-a68: #cc6888c2;
+  --color-text-secondary-a72: #cc6888cc;
+  --color-surface-hover-a34: #35081057;
+  --color-surface-hover-a54: #3508108a;
+  --color-outline-a72: #924057cc;
+  --color-outline-a78: #924057db;
+  --color-outline-a92: #924057eb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8205840, 0 0 0 4px #e820581f;
+  --shadow-error-ring: 0 0 0 1px #d010284c, 0 0 0 4px #d0102826;
+  --shadow-button-primary: 0 8px 24px #e820584c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8205833, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #a7113b);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #ea3769, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #92405780;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #24060ce5;
+  --color-sidebar-search-border: #92405766;
+  --color-sidebar-item-hover: #360811e5;
+  --color-sidebar-item-active: #360811eb;
+  --color-sidebar-item-active-border: #e8205829;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a02089e;
+  --color-surface-glass: #24060ceb;
+  --color-surface-glass-border: #2c09104c;
+  --color-surface-info: #350810;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #340a12;
+
+  /* 代码语法（色相: ring 343° 偏移 +20°）*/
+  --color-code-bg: #360811;
+  --color-code-fg: #ffd0dc;
+  --color-code-comment: #8a2e4b;
+  --color-code-keyword: #e82058;
+  --color-code-string: #74bb6e;
+  --color-code-function: #6e6ebb;
+  --color-code-number: #6eaebb;
+  --color-code-type: #8ebb6e;
+  --color-code-property: #fff7fa;
+  --color-code-parameter: #c24c72;
+  --color-code-punctuation: #ac3a5e;
+  --color-code-inserted: #4cd616;
+  --color-code-deleted: #d01028;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffd0dc;
+  --color-diff-syntax-comment: #8a2e4b;
+  --color-diff-syntax-string: #74bb6e;
+  --color-diff-syntax-number: #6eaebb;
+  --color-diff-syntax-regexp: #fff7fa;
+  --color-diff-syntax-keyword: #e82058;
+  --color-diff-syntax-variable: #cc6888;
+  --color-diff-syntax-parameter: #8a2e4b;
+  --color-diff-syntax-property: #fff7fa;
+  --color-diff-syntax-function: #6e6ebb;
+  --color-diff-syntax-type: #8ebb6e;
+  --color-diff-syntax-punctuation: #8a2e4b;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #91c98c;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d01028;
+  --color-diff-highlight-bg: #ea0744;
+  --color-diff-highlight-gutter: #bf0537;
+  --color-diff-title-bg: #350810;
+  --color-diff-title-color: #cc6888;
+  --color-diff-title-border: #4a101c;
+
+  /* 终端 */
+  --color-terminal-header: #360811;
+  --color-terminal-bg: #1a0208;
+  --color-terminal-border: #360811;
+  --color-terminal-fg: #ffd0dc;
+  --color-terminal-muted: #cc6888;
+  --color-terminal-accent: #74bb6e;
+  --color-terminal-danger: #d01028;
+  --color-terminal-warning: #e82058;
+
+  /* Inspector */
+  --color-inspector-surface: #27000c;
+  --color-inspector-panel: #360811;
+  --color-inspector-chip: #2a080e;
+  --color-inspector-border: #4a101c;
+  --color-inspector-accent: #e82058;
+  --color-inspector-accent-hover: #e93366;
+  --color-inspector-accent-secondary: #6e6ebb;
+  --color-inspector-text: #ffd0dc;
+  --color-inspector-heading: #ffd0dc;
+  --color-inspector-muted: #cc6888;
+  --color-inspector-muted-strong: #ffe0ec;
+  --color-inspector-success: #60b159;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d01028;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #bf0731;
+  --color-inspector-danger-border: #48050e;
+  --color-inspector-capacity: #924057;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a080e;
+  --color-activity-heat-1: #7f0924;
+  --color-activity-heat-2: #f4275a;
+  --color-activity-heat-3: #6b0b26;
+  --color-activity-heat-4: #e82058;
+  --color-activity-cell-border: #92405752;
+  --color-activity-cell-border-hover: #e820588c;
+  --color-activity-cell-border-active: #ffd0dc;
+  --color-activity-tooltip-surface: #300a12;
+  --color-activity-tooltip-border: #92405733;
+  --color-activity-tooltip-text: #ffd0dc;
+  --color-activity-tooltip-muted: #fff7fa;
+
+  /* Memory/Goal */
+  --color-memory-accent: #924057;
+  --color-memory-surface: #2a080e;
+  --color-memory-border: #4a101c;
+  --color-memory-icon-bg: #360811;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e82058;
+  --color-switch-thumb: #1a0208;
+  --color-model-option-selected-bg: #360811;
+  --color-model-option-selected-border: #e8205833;
+
+  /* 其他 */
+  --color-window-close-hover: #d01028;
+  --color-selection-bg: #e820584c;
+  --color-selection-fg: #ffd0dc;
+  --color-chat-navigation-target: #e820581a;
+}
+

--- a/desktop/src/theme/custom/warm-amber-dark.css
+++ b/desktop/src/theme/custom/warm-amber-dark.css
@@ -1,0 +1,225 @@
+/* Custom warm-toned dark theme */
+/* Custom warm-toned dark theme */
+
+[data-theme-preset="warm-amber"] {
+  color-scheme: dark;
+
+  /* Surface 层级 */
+  --color-background: #1a0a08;
+  --color-on-background: #ffe8d8;
+  --color-surface: #240e0c;
+  --color-surface-dim: #1a0a08;
+  --color-surface-bright: #3a1814;
+  --color-surface-container-lowest: #2a100e;
+  --color-surface-container-low: #3a0f0f;
+  --color-surface-container: #301410;
+  --color-surface-container-high: #3a1814;
+  --color-surface-container-highest: #4a1c18;
+  --color-surface-variant: #250808;
+  --color-surface-sidebar: #100604;
+  --color-surface-hover: #390e0e;
+  --color-surface-selected: #34150d;
+
+  /* 文本 */
+  --color-on-surface: #ffe8d8;
+  --color-on-surface-variant: #ffd8c0;
+  --color-text-primary: #ffe8d8;
+  --color-text-secondary: #fff0e8;
+  --color-text-tertiary: #cc9078;
+
+  /* 品牌色 */
+  --color-primary: #e88060;
+  --color-on-primary: #1a0a08;
+  --color-primary-container: #802c12;
+  --color-primary-fixed: #f2b9a7;
+  --color-primary-fixed-dim: #ec9b82;
+  --color-brand: var(--color-primary);
+  --color-brand-hover: #eb9276;
+  --color-text-accent: #f4c4b5;
+
+  /* 辅色 */
+  --color-secondary: #4a1c18;
+  --color-secondary-container: #240e0c;
+  --color-tertiary: #e1b434;
+  --color-tertiary-container: #644d0e;
+
+  /* 边框 */
+  --color-outline: #925c4d;
+  --color-outline-variant: #4a1c18;
+  --color-border: #4a1c18;
+  --color-border-focus: #e88060;
+  --color-border-separator: #3a0f0f;
+
+  /* 状态色 */
+  --color-error: #d04030;
+  --color-error-container: #3e130e;
+  --color-on-error-container: #f1c6c2;
+  --color-success: #81c981;
+  --color-success-container: #193b19;
+  --color-info: #81a5c9;
+  --color-info-container: #192a3b;
+  --color-warning: #dac37f;
+  --color-warning-container: #3f3515;
+
+  /* 反转 */
+  --color-inverse-surface: #ffe8d8;
+  --color-inverse-on-surface: #1a0a08;
+  --color-inverse-primary: #f8dbd2;
+
+  /* 透明度 */
+  --color-text-primary-a78: #ffe8d8db;
+  --color-text-primary-a82: #ffe8d8e5;
+  --color-text-primary-a88: #ffe8d8f2;
+  --color-text-secondary-a68: #cc9078c2;
+  --color-text-secondary-a72: #cc9078cc;
+  --color-surface-hover-a34: #390e0e57;
+  --color-surface-hover-a54: #390e0e8a;
+  --color-outline-a72: #925c4dcc;
+  --color-outline-a78: #925c4ddb;
+  --color-outline-a92: #925c4deb;
+
+  /* 阴影 */
+  --shadow-dropdown: 0 4px 20px rgba(0,0,0,0.40), 0 12px 40px rgba(0,0,0,0.50);
+  --shadow-sidebar-filter: none;
+  --shadow-focus-ring: 0 0 0 1px #e8806040, 0 0 0 4px #e880601f;
+  --shadow-error-ring: 0 0 0 1px #d040304c, 0 0 0 4px #d0403026;
+  --shadow-button-primary: 0 8px 24px #e880604c;
+  --shadow-activity-cell-hover: 0 0 0 2px #e8806033, 0 8px 18px rgba(0,0,0,0.40);
+  --shadow-inspector: 0 28px 80px rgba(0,0,0,0.50);
+  --color-btn-primary-fg: var(--color-on-primary);
+  --gradient-btn-primary: linear-gradient(135deg, var(--color-primary), #c8451d);
+  --gradient-btn-primary-hover: linear-gradient(135deg, #ec967c, var(--color-primary));
+
+  /* 侧边栏 */
+  --color-sidebar-filter-bg: transparent;
+  --color-sidebar-filter-border: #925c4d80;
+  --color-sidebar-filter-icon-bg: transparent;
+  --color-sidebar-search-bg: #240e0ce5;
+  --color-sidebar-search-border: #925c4d66;
+  --color-sidebar-item-hover: #3a0f0fe5;
+  --color-sidebar-item-active: #3a0f0feb;
+  --color-sidebar-item-active-border: #e8806029;
+  --sidebar-panel-bg-image: none;
+
+  /* 玻璃效果 */
+  --color-overlay-scrim: #1a0a089e;
+  --color-surface-glass: #240e0ceb;
+  --color-surface-glass-border: #2c100e4c;
+  --color-surface-info: #390e0e;
+
+  /* 用户消息 */
+  --color-surface-user-msg: #341410;
+
+  /* 代码语法（色相: ring 14° 偏移 +20°）*/
+  --color-code-bg: #3a0f0f;
+  --color-code-fg: #ffe8d8;
+  --color-code-comment: #8d4e35;
+  --color-code-keyword: #e88060;
+  --color-code-string: #7bba75;
+  --color-code-function: #7575ba;
+  --color-code-number: #75afba;
+  --color-code-type: #92ba75;
+  --color-code-property: #ffffff;
+  --color-code-parameter: #c1785b;
+  --color-code-punctuation: #b06142;
+  --color-code-inserted: #42e369;
+  --color-code-deleted: #d04030;
+
+  /* Diff 语法 */
+  --color-diff-syntax-foreground: #ffe8d8;
+  --color-diff-syntax-comment: #8d4e35;
+  --color-diff-syntax-string: #7bba75;
+  --color-diff-syntax-number: #75afba;
+  --color-diff-syntax-regexp: #ffffff;
+  --color-diff-syntax-keyword: #e88060;
+  --color-diff-syntax-variable: #cc9078;
+  --color-diff-syntax-parameter: #8d4e35;
+  --color-diff-syntax-property: #ffffff;
+  --color-diff-syntax-function: #7575ba;
+  --color-diff-syntax-type: #92ba75;
+  --color-diff-syntax-punctuation: #8d4e35;
+
+  /* Diff 增/删 */
+  --color-diff-added-bg: #162812;
+  --color-diff-added-word: #2a4a20;
+  --color-diff-added-gutter: #1a3616;
+  --color-diff-added-text: #97c993;
+  --color-diff-removed-bg: #2a100a;
+  --color-diff-removed-word: #4a1a10;
+  --color-diff-removed-gutter: #38140a;
+  --color-diff-removed-text: #d04030;
+  --color-diff-highlight-bg: #cb5649;
+  --color-diff-highlight-gutter: #b03e32;
+  --color-diff-title-bg: #390e0e;
+  --color-diff-title-color: #cc9078;
+  --color-diff-title-border: #4a1c18;
+
+  /* 终端 */
+  --color-terminal-header: #3a0f0f;
+  --color-terminal-bg: #1a0a08;
+  --color-terminal-border: #3a0f0f;
+  --color-terminal-fg: #ffe8d8;
+  --color-terminal-muted: #cc9078;
+  --color-terminal-accent: #7bba75;
+  --color-terminal-danger: #d04030;
+  --color-terminal-warning: #e88060;
+
+  /* Inspector */
+  --color-inspector-surface: #1e0707;
+  --color-inspector-panel: #3a0f0f;
+  --color-inspector-chip: #2a100e;
+  --color-inspector-border: #4a1c18;
+  --color-inspector-accent: #e88060;
+  --color-inspector-accent-hover: #eb9276;
+  --color-inspector-accent-secondary: #7575ba;
+  --color-inspector-text: #ffe8d8;
+  --color-inspector-heading: #ffe8d8;
+  --color-inspector-muted: #cc9078;
+  --color-inspector-muted-strong: #fff0e8;
+  --color-inspector-success: #67af60;
+  --color-inspector-success-bg: #162812;
+  --color-inspector-danger: #d04030;
+  --color-inspector-danger-bg: #2a100a;
+  --color-inspector-danger-surface: #822c1e;
+  --color-inspector-danger-border: #491610;
+  --color-inspector-capacity: #925c4d;
+
+  /* 活动热图 */
+  --color-activity-heat-0: #2a100e;
+  --color-activity-heat-1: #802b1e;
+  --color-activity-heat-2: #de9184;
+  --color-activity-heat-3: #802c12;
+  --color-activity-heat-4: #e88060;
+  --color-activity-cell-border: #925c4d52;
+  --color-activity-cell-border-hover: #e880608c;
+  --color-activity-cell-border-active: #ffe8d8;
+  --color-activity-tooltip-surface: #301410;
+  --color-activity-tooltip-border: #925c4d33;
+  --color-activity-tooltip-text: #ffe8d8;
+  --color-activity-tooltip-muted: #ffffff;
+
+  /* Memory/Goal */
+  --color-memory-accent: #925c4d;
+  --color-memory-surface: #2a100e;
+  --color-memory-border: #4a1c18;
+  --color-memory-icon-bg: #3a0f0f;
+  --color-goal-accent: var(--color-memory-accent);
+  --color-goal-surface: var(--color-memory-surface);
+  --color-goal-border: var(--color-memory-border);
+  --color-goal-icon-bg: var(--color-memory-icon-bg);
+  --color-goal-chip-bg: var(--color-surface);
+  --color-goal-chip-border: var(--color-border);
+
+  /* 开关 */
+  --color-switch-checked-bg: #e88060;
+  --color-switch-thumb: #1a0a08;
+  --color-model-option-selected-bg: #3a0f0f;
+  --color-model-option-selected-border: #e8806033;
+
+  /* 其他 */
+  --color-window-close-hover: #d04030;
+  --color-selection-bg: #e880604c;
+  --color-selection-fg: #ffe8d8;
+  --color-chat-navigation-target: #e880601a;
+}
+


### PR DESCRIPTION
## What

Adds **16 curated warm-toned dark theme presets** plus theme UX improvements.

### Themes
Velvet Crimson, Plum Bruise, Pearl White, Warm Amber, Rose Quartz, Deep Crimson, Burnt Amber, Dusk Magenta, Clay Earth, Twilight Violet, Blush Petal, Midnight Plum, Storm Indigo, Coral Blush, Dawn Flush, Spring Peach.

All `color-scheme: dark`, derived from VSCode community themes.

### UX Improvements
- **Mutual exclusion**: dropdown preset selected = 3 system theme buttons deselect
- **Delete confirmation**: prompt before removing theme

### Files: 17 changed (1 settings + 16 CSS)