### PR TITLE
fix(provider): add MiniMax regional endpoints

### DIFF
--- a/desktop/src/config/providerPresets.test.ts
+++ b/desktop/src/config/providerPresets.test.ts
@@ -37,6 +37,16 @@ describe('selectableProviderPresets', () => {
 })
 
 describe('bundled provider presets', () => {
+  it('includes both MiniMax regional Anthropic endpoints', () => {
+    const minimax = BUNDLED_PROVIDER_PRESETS.find((preset) => preset.id === 'minimax')
+
+    expect(minimax?.baseUrl).toBe('https://api.minimax.io/anthropic')
+    expect(minimax?.regionalEndpoints).toEqual([
+      { region: 'global_en', baseUrl: 'https://api.minimax.io/anthropic' },
+      { region: 'cn_zh', baseUrl: 'https://api.minimaxi.com/anthropic' },
+    ])
+  })
+
   // Retiring a preset must not break providers already configured against it: the
   // bundle keeps the entry so the edit form can still resolve its presetId, while
   // the "add provider" chips are built from selectableProviderPresets.

--- a/desktop/src/types/providerPreset.ts
+++ b/desktop/src/types/providerPreset.ts
@@ -8,10 +8,16 @@ export type ModelMapping = {
   opus: string
 }
 
+export type ProviderRegionalEndpoint = {
+  region: string
+  baseUrl: string
+}
+
 export type ProviderPreset = {
   id: string
   name: string
   baseUrl: string
+  regionalEndpoints?: ProviderRegionalEndpoint[]
   apiFormat: ApiFormat
   defaultModels: ModelMapping
   needsApiKey: boolean

--- a/src/server/__tests__/provider-presets.test.ts
+++ b/src/server/__tests__/provider-presets.test.ts
@@ -100,6 +100,11 @@ describe('provider presets API', () => {
     expect(kimi?.defaultEnv?.ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES).toBe(
       'thinking,required_thinking,effort,max_effort',
     )
+    expect(minimax?.baseUrl).toBe('https://api.minimax.io/anthropic')
+    expect(minimax?.regionalEndpoints).toEqual([
+      { region: 'global_en', baseUrl: 'https://api.minimax.io/anthropic' },
+      { region: 'cn_zh', baseUrl: 'https://api.minimaxi.com/anthropic' },
+    ])
     expect(minimax?.authStrategy).toBe('auth_token')
     expect(minimax?.defaultModels.main).toBe('MiniMax-M3[1m]')
     expect(minimax?.defaultEnv?.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1000000')

--- a/src/server/config/providerPresets.json
+++ b/src/server/config/providerPresets.json
@@ -103,7 +103,17 @@
   {
     "id": "minimax",
     "name": "MiniMax",
-    "baseUrl": "https://api.minimaxi.com/anthropic",
+    "baseUrl": "https://api.minimax.io/anthropic",
+    "regionalEndpoints": [
+      {
+        "region": "global_en",
+        "baseUrl": "https://api.minimax.io/anthropic"
+      },
+      {
+        "region": "cn_zh",
+        "baseUrl": "https://api.minimaxi.com/anthropic"
+      }
+    ],
     "apiFormat": "anthropic",
     "defaultModels": {
       "main": "MiniMax-M3[1m]",

--- a/src/server/config/providerPresets.ts
+++ b/src/server/config/providerPresets.ts
@@ -14,10 +14,16 @@ const ModelMappingSchema = z.object({
   opus: z.string(),
 })
 
+const ProviderRegionalEndpointSchema = z.object({
+  region: z.string().min(1),
+  baseUrl: z.string().url(),
+})
+
 const ProviderPresetSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
   baseUrl: z.string(),
+  regionalEndpoints: z.array(ProviderRegionalEndpointSchema).min(1).optional(),
   apiFormat: ApiFormatSchema,
   defaultModels: ModelMappingSchema,
   needsApiKey: z.boolean(),


### PR DESCRIPTION
Reason: The MiniMax preset only exposed the China Anthropic endpoint and did not represent both supported regions as structured options.

- Use the global Anthropic endpoint as the preset default.
- Add `global_en` and `cn_zh` entries to structured regional endpoint metadata.
- Keep the server schema, desktop type, and focused preset tests aligned.

Checks:
- `jq empty src/server/config/providerPresets.json`
- `./desktop/node_modules/.bin/tsc --noEmit --skipLibCheck --target ESNext --module ESNext --moduleResolution bundler --resolveJsonModule --allowSyntheticDefaultImports src/server/config/providerPresets.ts`
- `cd desktop && bun run test -- --run src/config/providerPresets.test.ts`
