### PR TITLE
fix(desktop): ignore failed TaskUpdate status changes

### DIFF
--- a/desktop/src/components/activity/sessionActivityModel.test.ts
+++ b/desktop/src/components/activity/sessionActivityModel.test.ts
@@ -541,6 +541,75 @@ describe('buildSessionActivityModel', () => {
     expect(model.badgeCount).toBe(1)
   })
 
+  it('keeps the last successful task status when a later TaskUpdate fails', () => {
+    const model = buildSessionActivityModel({
+      sessionId: 'session-1',
+      messages: [
+        {
+          id: 'task-create-1',
+          type: 'tool_use',
+          toolName: 'TaskCreate',
+          toolUseId: 'task-create-call-1',
+          input: { subject: 'Review the activity panel' },
+          timestamp: 1000,
+        },
+        {
+          id: 'task-create-result-1',
+          type: 'tool_result',
+          toolUseId: 'task-create-call-1',
+          content: 'Task #2 created successfully: Review the activity panel',
+          isError: false,
+          timestamp: 1001,
+        },
+        {
+          id: 'task-completed',
+          type: 'tool_use',
+          toolName: 'TaskUpdate',
+          toolUseId: 'task-completed-call',
+          input: { taskId: '2', status: 'completed' },
+          timestamp: 1002,
+        },
+        {
+          id: 'task-completed-result',
+          type: 'tool_result',
+          toolUseId: 'task-completed-call',
+          content: 'Updated task #2 status',
+          isError: false,
+          timestamp: 1003,
+        },
+        {
+          id: 'task-reopen',
+          type: 'tool_use',
+          toolName: 'TaskUpdate',
+          toolUseId: 'task-reopen-call',
+          input: { taskId: '2', status: 'in_progress' },
+          timestamp: 1004,
+        },
+        {
+          id: 'task-reopen-result',
+          type: 'tool_result',
+          toolUseId: 'task-reopen-call',
+          content: 'Task not found',
+          isError: false,
+          timestamp: 1005,
+        },
+      ],
+      tasks: [],
+      completedAndDismissed: false,
+      backgroundTasks: [],
+      agentNotifications: [],
+    })
+
+    expect(model.sections.tasks.rows).toEqual([
+      expect.objectContaining({
+        id: '2',
+        label: 'Review the activity panel',
+        status: 'completed',
+      }),
+    ])
+    expect(model.badgeCount).toBe(0)
+  })
+
   it('drops tasks deleted by TaskUpdate instead of showing them as pending', () => {
     const model = buildSessionActivityModel({
       sessionId: 'session-1',

--- a/desktop/src/components/activity/sessionActivityModel.test.ts
+++ b/desktop/src/components/activity/sessionActivityModel.test.ts
@@ -610,7 +610,7 @@ describe('buildSessionActivityModel', () => {
     expect(model.badgeCount).toBe(0)
   })
 
-  it('drops tasks deleted by TaskUpdate instead of showing them as pending', () => {
+  it('hides tasks while a TaskUpdate deletion is pending', () => {
     const model = buildSessionActivityModel({
       sessionId: 'session-1',
       messages: [
@@ -673,6 +673,128 @@ describe('buildSessionActivityModel', () => {
       expect.objectContaining({ id: '2', label: '给 summarize 加空数组保护', status: 'completed' }),
     ])
     expect(model.badgeCount).toBe(0)
+  })
+
+  it('matches TaskUpdate deletion results by toolUseId and keeps tasks whose deletions fail', () => {
+    const model = buildSessionActivityModel({
+      sessionId: 'session-1',
+      messages: [
+        {
+          id: 'task-create-1',
+          type: 'tool_use',
+          toolName: 'TaskCreate',
+          toolUseId: 'task-create-call-1',
+          input: { subject: 'Delete succeeds' },
+          timestamp: 1000,
+        },
+        {
+          id: 'task-create-result-1',
+          type: 'tool_result',
+          toolUseId: 'task-create-call-1',
+          content: 'Task #1 created successfully: Delete succeeds',
+          isError: false,
+          timestamp: 1001,
+        },
+        {
+          id: 'task-create-2',
+          type: 'tool_use',
+          toolName: 'TaskCreate',
+          toolUseId: 'task-create-call-2',
+          input: { subject: 'Recoverable delete failure' },
+          timestamp: 1002,
+        },
+        {
+          id: 'task-create-result-2',
+          type: 'tool_result',
+          toolUseId: 'task-create-call-2',
+          content: 'Task #2 created successfully: Recoverable delete failure',
+          isError: false,
+          timestamp: 1003,
+        },
+        {
+          id: 'task-create-3',
+          type: 'tool_use',
+          toolName: 'TaskCreate',
+          toolUseId: 'task-create-call-3',
+          input: { subject: 'Error delete failure' },
+          timestamp: 1004,
+        },
+        {
+          id: 'task-create-result-3',
+          type: 'tool_result',
+          toolUseId: 'task-create-call-3',
+          content: 'Task #3 created successfully: Error delete failure',
+          isError: false,
+          timestamp: 1005,
+        },
+        {
+          id: 'task-delete-1',
+          type: 'tool_use',
+          toolName: 'TaskUpdate',
+          toolUseId: 'task-delete-call-1',
+          input: { taskId: '1', status: 'deleted' },
+          timestamp: 1006,
+        },
+        {
+          id: 'task-delete-2',
+          type: 'tool_use',
+          toolName: 'TaskUpdate',
+          toolUseId: 'task-delete-call-2',
+          input: { taskId: '2', status: 'deleted' },
+          timestamp: 1007,
+        },
+        {
+          id: 'task-delete-3',
+          type: 'tool_use',
+          toolName: 'TaskUpdate',
+          toolUseId: 'task-delete-call-3',
+          input: { taskId: '3', status: 'deleted' },
+          timestamp: 1008,
+        },
+        // Results arrive in a different order from the tool calls. They must be
+        // matched by toolUseId rather than by task ID or message adjacency.
+        {
+          id: 'task-delete-result-3',
+          type: 'tool_result',
+          toolUseId: 'task-delete-call-3',
+          content: 'Failed to delete task',
+          isError: true,
+          timestamp: 1009,
+        },
+        {
+          id: 'task-delete-result-2',
+          type: 'tool_result',
+          toolUseId: 'task-delete-call-2',
+          content: 'Task not found',
+          isError: false,
+          timestamp: 1010,
+        },
+        {
+          id: 'task-delete-result-1',
+          type: 'tool_result',
+          toolUseId: 'task-delete-call-1',
+          content: 'Updated task #1 deleted',
+          isError: false,
+          timestamp: 1011,
+        },
+      ],
+      // A refresh can still contain all three tasks while tool results are being
+      // reconciled. Only the confirmed deletion should hide its stale live row.
+      tasks: [
+        task({ id: '1', subject: 'Delete succeeds', status: 'pending' }),
+        task({ id: '2', subject: 'Recoverable delete failure', status: 'pending' }),
+        task({ id: '3', subject: 'Error delete failure', status: 'pending' }),
+      ],
+      completedAndDismissed: false,
+      backgroundTasks: [],
+      agentNotifications: [],
+    })
+
+    expect(model.sections.tasks.rows).toEqual([
+      expect.objectContaining({ id: '2', label: 'Recoverable delete failure', status: 'pending' }),
+      expect.objectContaining({ id: '3', label: 'Error delete failure', status: 'pending' }),
+    ])
+    expect(model.badgeCount).toBe(2)
   })
 
   it('does not invent a row for a TaskUpdate deletion without a matching TaskCreate', () => {

--- a/desktop/src/components/activity/sessionActivityModel.ts
+++ b/desktop/src/components/activity/sessionActivityModel.ts
@@ -263,12 +263,29 @@ function isDeletedStatus(input: Record<string, unknown>): boolean {
   return stringField(input, 'status') === 'deleted'
 }
 
+type ToolResultMessage = Extract<UIMessage, { type: 'tool_result' }>
+
+function collectToolResultsByUseId(messages: UIMessage[]): Map<string, ToolResultMessage> {
+  const resultsByToolUseId = new Map<string, ToolResultMessage>()
+  for (const message of messages) {
+    if (message.type === 'tool_result') {
+      resultsByToolUseId.set(message.toolUseId, message)
+    }
+  }
+  return resultsByToolUseId
+}
+
+function shouldApplyTaskUpdate(taskId: string, result?: ToolResultMessage): boolean {
+  return !result || (!result.isError && parseUpdatedTaskId(result.content) === taskId)
+}
+
 /**
  * TaskUpdate 的 deleted 是删除动作而非状态，删除可能发生在创建它的那一轮之后，
  * 所以要跨轮次收集，避免已删任务留在历史统计里。
  */
 function collectDeletedTaskIds(messages: UIMessage[]): Set<string> {
   const deletedTaskIds = new Set<string>()
+  const resultsByToolUseId = collectToolResultsByUseId(messages)
 
   for (const message of messages) {
     if (message.type !== 'tool_use' || message.toolName !== 'TaskUpdate') continue
@@ -277,7 +294,9 @@ function collectDeletedTaskIds(messages: UIMessage[]): Set<string> {
     if (!isDeletedStatus(input)) continue
 
     const taskId = taskIdFromInput(input)
-    if (taskId) deletedTaskIds.add(taskId)
+    if (!taskId) continue
+    if (!shouldApplyTaskUpdate(taskId, resultsByToolUseId.get(message.toolUseId))) continue
+    deletedTaskIds.add(taskId)
   }
 
   return deletedTaskIds
@@ -456,12 +475,7 @@ function buildAgentRowsFromMessages(messages: UIMessage[]): ActivityRow[] {
 }
 
 function buildTaskRowsFromTaskTools(messages: UIMessage[]): ActivityRow[] {
-  const resultsByToolUseId = new Map<string, Extract<UIMessage, { type: 'tool_result' }>>()
-  for (const message of messages) {
-    if (message.type === 'tool_result') {
-      resultsByToolUseId.set(message.toolUseId, message)
-    }
-  }
+  const resultsByToolUseId = collectToolResultsByUseId(messages)
 
   const rowsByTaskId = new Map<string, ActivityRow>()
   let createIndex = 0
@@ -484,17 +498,17 @@ function buildTaskRowsFromTaskTools(messages: UIMessage[]): ActivityRow[] {
       const taskId = taskIdFromInput(input)
       if (!taskId) continue
 
+      // TaskUpdate intentionally reports recoverable failures such as "Task not found"
+      // as non-error tool results. Keep optimistic updates while a call is pending, but
+      // discard its input once the corresponding result proves it did not succeed.
+      const result = resultsByToolUseId.get(message.toolUseId)
+      if (!shouldApplyTaskUpdate(taskId, result)) continue
+
       // deleted 不是一种任务状态：CLI 侧 TaskUpdateTool 会真的删掉任务文件
       if (isDeletedStatus(input)) {
         rowsByTaskId.delete(taskId)
         continue
       }
-
-      // TaskUpdate intentionally reports recoverable failures such as "Task not found"
-      // as non-error tool results. Keep optimistic updates while a call is pending, but
-      // discard its input once the corresponding result proves it did not succeed.
-      const result = resultsByToolUseId.get(message.toolUseId)
-      if (result && (result.isError || parseUpdatedTaskId(result.content) !== taskId)) continue
 
       const existing = rowsByTaskId.get(taskId)
       const activeForm = stringField(input, 'activeForm')

--- a/desktop/src/components/activity/sessionActivityModel.ts
+++ b/desktop/src/components/activity/sessionActivityModel.ts
@@ -294,6 +294,12 @@ function parseCreatedTaskResult(content: unknown): { id: string; subject?: strin
   }
 }
 
+function parseUpdatedTaskId(content: unknown): string | null {
+  const text = extractTextContent(content)
+  const match = text.match(/^Updated task #(\S+)(?:\s|$)/i)
+  return match?.[1] ?? null
+}
+
 function buildTaskToolRow(
   id: string,
   input: Record<string, unknown>,
@@ -483,6 +489,12 @@ function buildTaskRowsFromTaskTools(messages: UIMessage[]): ActivityRow[] {
         rowsByTaskId.delete(taskId)
         continue
       }
+
+      // TaskUpdate intentionally reports recoverable failures such as "Task not found"
+      // as non-error tool results. Keep optimistic updates while a call is pending, but
+      // discard its input once the corresponding result proves it did not succeed.
+      const result = resultsByToolUseId.get(message.toolUseId)
+      if (result && (result.isError || parseUpdatedTaskId(result.content) !== taskId)) continue
 
       const existing = rowsByTaskId.get(taskId)
       const activeForm = stringField(input, 'activeForm')


### PR DESCRIPTION
## TL;DR

修复了 TaskUpdate 执行失败（如返回 "Task not found" 或删除失败）时，Activity 面板仍然会误改状态或把任务从 UI 里误删的问题。

## 改动点

1. **按 toolUseId 精确校验**：只有 `tool_result` 确认成功（`isError: false` 且 taskId 对应）时才更新或删除任务。
2. **失败正确回滚**：遇到 TaskUpdate 失败或报错时，保留历史 Task 和 liveTasks，不再强行在 UI 中隐藏或改动状态。
3. **保留乐观 UI 体验**：在 `tool_result` 还没返回时依然保持乐观隐藏/更新，一旦发现执行失败才恢复原状。

## 测试

- 补齐了 TaskUpdate 各种成功、报错、Recoverable 失败以及结果逆序到达的单元测试（31/31 passed）。

Fixes #1155

## Feature Quality Contract

- Changed surface: desktop
- Tests added or updated:
  - Added regression coverage for successful, pending, recoverable-failure, error, and out-of-order `TaskUpdate` results.
- Coverage evidence:
  - GitHub `coverage-checks` passed for commit `c6e7f73a`.
- E2E / live-model evidence:
  - Not run. This is a local activity-model projection change covered by unit tests.
- Known risk / rollback:
  - Success detection follows the existing `TaskUpdateTool` result format. Revert commits `c6e7f73a` and `aeb3026f` to roll back the change.

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
- [x] I added or updated same-area tests for every production behavior change.
- [x] GitHub selected and passed `desktop-checks` and `coverage-checks` for the current diff.
- [x] New or changed executable production lines passed the changed-line coverage gate.
- [x] GitHub PR Quality run `30688454456` completed successfully.
- [x] Deterministic unit tests cover this local projection change; live-model evidence does not apply.

Local results:

- `sessionActivityModel.test.ts`: 31/31 passed.
- Activity component tests: 59/59 passed.
- `node ./node_modules/typescript/bin/tsc --noEmit`: passed.
- `git diff --check`: passed.

GitHub results:

- `desktop-checks`: passed.
- `coverage-checks`: passed.
- `policy-enforcement`: passed.
- `pr-quality-gate`: passed.

## Risk

- [x] This PR does not touch CLI core paths.
- [x] Production code changes include matching tests.
- [x] This PR does not change coverage baselines or thresholds.
- [x] This PR does not change quarantine policy.
- [x] This PR does not change provider or runtime behavior.
