### PR TITLE
fix(desktop): dedupe Windows MCP project paths

### DIFF
--- a/desktop/src/__tests__/mcpStoreKnownProjects.test.ts
+++ b/desktop/src/__tests__/mcpStoreKnownProjects.test.ts
@@ -19,6 +19,7 @@ vi.mock('../api/mcp', async (importOriginal) => {
       ...actual.mcpApi,
       projectPaths: vi.fn(),
       list: vi.fn(),
+      toggle: vi.fn(),
     },
   }
 })
@@ -50,6 +51,7 @@ describe('fetchServersForKnownProjects', () => {
     vi.mocked(sessionsApi.getRecentProjects).mockReset()
     vi.mocked(mcpApi.projectPaths).mockReset()
     vi.mocked(mcpApi.list).mockReset()
+    vi.mocked(mcpApi.toggle).mockReset()
   })
 
   it('queries the union of current cwd, recent projects, and configured MCP paths', async () => {
@@ -66,6 +68,85 @@ describe('fetchServersForKnownProjects', () => {
     const queried = vi.mocked(mcpApi.list).mock.calls.map(([cwd]) => cwd)
     expect(queried).toEqual(['/proj/current', '/proj/recent', '/proj/with-mcp'])
     expect(useMcpStore.getState().servers.map((s) => s.name)).toEqual(['shared-tools'])
+  })
+
+  it('deduplicates Windows separator variants while preserving the first path', async () => {
+    const sessionPath = 'C:\\UE\\StrangeAutumn'
+    vi.mocked(sessionsApi.getRecentProjects).mockResolvedValue({
+      projects: [{ realPath: sessionPath }],
+    } as Awaited<ReturnType<typeof sessionsApi.getRecentProjects>>)
+    vi.mocked(mcpApi.projectPaths).mockResolvedValue({
+      projectPaths: ['C:/UE/StrangeAutumn'],
+    })
+    vi.mocked(mcpApi.list).mockResolvedValue({
+      servers: [record('shared-tools', 'project')],
+    })
+
+    await useMcpStore.getState().fetchServersForKnownProjects(sessionPath)
+
+    expect(vi.mocked(mcpApi.list).mock.calls.map(([cwd]) => cwd)).toEqual([sessionPath])
+    expect(useMcpStore.getState().servers).toEqual([
+      expect.objectContaining({
+        name: 'shared-tools',
+        projectPath: sessionPath,
+      }),
+    ])
+  })
+
+  it('replaces a server when an action uses the other Windows separator style', async () => {
+    const existing = {
+      ...record('shared-tools', 'project'),
+      projectPath: 'C:\\UE\\StrangeAutumn',
+    }
+    const equivalent = {
+      ...existing,
+      projectPath: 'C:/UE/StrangeAutumn',
+    }
+    useMcpStore.setState({ servers: [existing], selectedServer: existing })
+    vi.mocked(mcpApi.toggle).mockResolvedValue({
+      server: { ...record('shared-tools', 'project'), enabled: false },
+    })
+
+    await useMcpStore.getState().toggleServer(equivalent, equivalent.projectPath)
+
+    expect(useMcpStore.getState().servers).toEqual([
+      expect.objectContaining({
+        name: 'shared-tools',
+        enabled: false,
+        projectPath: equivalent.projectPath,
+      }),
+    ])
+    expect(useMcpStore.getState().selectedServer).toEqual(
+      expect.objectContaining({
+        enabled: false,
+        projectPath: equivalent.projectPath,
+      }),
+    )
+  })
+
+  it('keeps same-named servers from different projects separate', async () => {
+    vi.mocked(mcpApi.list).mockResolvedValue({
+      servers: [record('shared-tools', 'project')],
+    })
+
+    await useMcpStore.getState().fetchServers(['C:/project-a', 'C:/project-b'])
+
+    expect(useMcpStore.getState().servers.map((server) => server.projectPath)).toEqual([
+      'C:/project-a',
+      'C:/project-b',
+    ])
+  })
+
+  it('does not treat a backslash in a POSIX filename as a path separator', async () => {
+    const projectPaths = ['/tmp/project\\name', '/tmp/project/name']
+    vi.mocked(mcpApi.list).mockResolvedValue({
+      servers: [record('shared-tools', 'project')],
+    })
+
+    await useMcpStore.getState().fetchServers(projectPaths)
+
+    expect(vi.mocked(mcpApi.list).mock.calls.map(([cwd]) => cwd)).toEqual(projectPaths)
+    expect(useMcpStore.getState().servers.map((server) => server.projectPath)).toEqual(projectPaths)
   })
 
   it('does not collapse the list to a single-project view when discovery sources fail (GH #1126)', async () => {

--- a/desktop/src/stores/mcpStore.ts
+++ b/desktop/src/stores/mcpStore.ts
@@ -43,6 +43,21 @@ function isProjectScoped(server: Pick<McpServerRecord, 'scope'>) {
   return server.scope === 'local' || server.scope === 'project'
 }
 
+function projectPathIdentity(projectPath?: string) {
+  const value = projectPath ?? ''
+  if (!/^(?:[A-Za-z]:[\\/]|\\\\)/.test(value)) return value
+  return value.replace(/\\/g, '/')
+}
+
+function dedupeProjectPaths(projectPaths: string[]) {
+  const uniquePaths = new Map<string, string>()
+  for (const projectPath of projectPaths) {
+    const identity = projectPathIdentity(projectPath)
+    if (!uniquePaths.has(identity)) uniquePaths.set(identity, projectPath)
+  }
+  return [...uniquePaths.values()]
+}
+
 function attachProjectPath(server: McpServerRecord, cwd?: string) {
   if (!isProjectScoped(server)) {
     return {
@@ -60,7 +75,7 @@ function attachProjectPath(server: McpServerRecord, cwd?: string) {
 function isSameServer(a: Pick<McpServerRecord, 'name' | 'scope' | 'projectPath'>, b: Pick<McpServerRecord, 'name' | 'scope' | 'projectPath'>) {
   if (a.name !== b.name || a.scope !== b.scope) return false
   if (!isProjectScoped(a) && !isProjectScoped(b)) return true
-  return (a.projectPath ?? '') === (b.projectPath ?? '')
+  return projectPathIdentity(a.projectPath) === projectPathIdentity(b.projectPath)
 }
 
 function replaceServer(
@@ -88,8 +103,8 @@ export const useMcpStore = create<McpStore>((set, get) => ({
     const requestId = ++fetchServersRequestId
     set({ isLoading: true, error: null })
     try {
-      const normalizedPaths = Array.from(new Set((projectPaths ?? []).filter(Boolean)))
-      const contexts = normalizedPaths.length > 0 ? normalizedPaths : [fallbackCwd].filter(Boolean)
+      const uniquePaths = dedupeProjectPaths((projectPaths ?? []).filter(Boolean))
+      const contexts = uniquePaths.length > 0 ? uniquePaths : [fallbackCwd].filter(Boolean)
 
       const responses = await Promise.all(
         (contexts.length > 0 ? contexts : [undefined]).map(async (cwd) => {
@@ -106,7 +121,7 @@ export const useMcpStore = create<McpStore>((set, get) => ({
         for (const server of group) {
           const key =
             server.scope === 'local' || server.scope === 'project'
-              ? `${server.scope}:${server.projectPath}:${server.name}`
+              ? `${server.scope}:${projectPathIdentity(server.projectPath)}:${server.name}`
               : `${server.scope}:${server.name}`
           if (!deduped.has(key)) {
             deduped.set(key, server)


### PR DESCRIPTION
## TL;DR

修复 Windows 下同一个项目因为路径写法不同（`C:\...` 和 `C:/...`），在 MCP 面板重复出现的问题。现在这两种路径会被认作同一个项目，不会再出现两个条目一起启用或禁用的情况。

## 改动点

1. **统一 Windows 路径判断**：比较项目时，`C:\...` 和 `C:/...` 会按同一路径处理。
2. **保留原始路径**：只在内部比较时统一分隔符，界面显示和接口调用仍使用原路径。
3. **避免误合并**：不同项目里的同名 MCP 仍然分开；Linux 和 macOS 路径不受影响。

## 测试

- 补了 4 组回归测试，覆盖路径重复、不同路径写法下的状态更新、不同项目里的同名 MCP，以及 POSIX 文件名中的反斜杠。
- 相关测试 23/23 通过，TypeScript 检查和构建通过。
- 本地全量桌面测试中，本次改动涉及的测试通过；另外 12 个失败来自已有的 Windows 软链接和主题测试。
- 同一提交的 GitHub PR Quality run `30685257865` 全部通过。
- 转为 Ready 后的重跑中，桌面检查通过，改动行覆盖率为 100%（17/17）；共享覆盖率任务没有发现根目录测试文件（0/254），因此该轮总检查失败。

Fixes #1165

## Feature Quality Contract

- Changed surface: desktop
- Changed files:
  - `desktop/src/stores/mcpStore.ts`
  - `desktop/src/__tests__/mcpStoreKnownProjects.test.ts`
- Tests added or updated:
  - Windows separator variants, mixed-separator updates, same-named servers in different projects, and POSIX filenames containing backslashes.
- Coverage evidence:
  - Changed lines: 100% (17/17).
  - Targeted LCOV: `artifacts/coverage/issue-1165-targeted/lcov.info`.
  - Full local report: `artifacts/coverage/2026-08-01T05-01-42-495Z/coverage-report.md`.
- E2E / live-model evidence:
  - Not run. This is desktop store logic covered with mocked MCP responses.
- Known risk / rollback:
  - Drive-letter case and trailing separators are outside this fix. Revert `f334817f` to restore the previous behavior.