### PR TITLE
fix(activity): keep subagent bash tasks out of main session

### DIFF
--- a/src/tasks/stopTask.test.ts
+++ b/src/tasks/stopTask.test.ts
@@ -9,7 +9,7 @@ import type { SessionId } from '../types/ids.js'
 import { drainSdkEvents } from '../utils/sdkEventQueue.js'
 import { stopTask } from './stopTask.js'
 
-function makeShellTaskHarness() {
+function makeShellTaskHarness(agentId?: string) {
   let killed = false
   let state = {
     tasks: {
@@ -33,6 +33,7 @@ function makeShellTaskHarness() {
         },
         lastReportedTotalLines: 0,
         isBackgrounded: true,
+        agentId,
       },
     },
   } as unknown as AppState
@@ -82,5 +83,18 @@ describe('stopTask SDK events', () => {
       summary: 'Sleep for 300 seconds',
       session_id: 'stop-task-sdk-events',
     }))
+  })
+
+  test('does not emit a session bookend for a subagent-owned shell task', async () => {
+    const harness = makeShellTaskHarness('subagent-1')
+
+    await stopTask('btask123', {
+      getAppState: () => harness.state,
+      setAppState: harness.setAppState,
+    })
+
+    expect(harness.killed).toBe(true)
+    expect(harness.state.tasks.btask123?.status).toBe('killed')
+    expect(drainSdkEvents()).toEqual([])
   })
 })

--- a/src/tasks/stopTask.ts
+++ b/src/tasks/stopTask.ts
@@ -65,7 +65,8 @@ export async function stopTask(
   // LocalShellTask.kill() atomically marks the task notified before returning.
   // Capture the pre-kill state so the desktop SDK bookend is not suppressed by
   // that implementation detail.
-  const shouldEmitShellTermination = isLocalShellTask(task) && !task.notified
+  const shouldEmitShellTermination =
+    isLocalShellTask(task) && !task.agentId && !task.notified
 
   await taskImpl.kill(taskId, setAppState)
 

--- a/src/utils/sdkEventQueue.ts
+++ b/src/utils/sdkEventQueue.ts
@@ -139,7 +139,9 @@ export function drainSdkEvents(): Array<
 /**
  * Emit a task_notification SDK event for a task reaching a terminal state.
  *
- * registerTask() always emits task_started; this is the closing bookend.
+ * registerTask() emits task_started for session-visible tasks; this is their
+ * closing bookend. Agent-owned shell tasks stay scoped to their Agent tool call
+ * and intentionally do not enter the session task event stream.
  * Call this from any exit path that sets a task terminal WITHOUT going
  * through enqueuePendingNotification-with-<task-id> (print.ts parses that
  * XML into the same SDK event, so paths that do both would double-emit).

--- a/src/utils/task/framework.test.ts
+++ b/src/utils/task/framework.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../bootstrap/state.js'
 import type { AppState } from '../../state/AppState.js'
 import type { RemoteAgentTaskState } from '../../tasks/RemoteAgentTask/RemoteAgentTask.js'
+import type { TaskState } from '../../tasks/types.js'
 import type { SessionId } from '../../types/ids.js'
 import { drainSdkEvents } from '../sdkEventQueue.js'
 import { registerTask } from './framework.js'
@@ -43,5 +44,86 @@ test('includes the remote session id in remote Agent start events', () => {
     task_id: 'remote-task-1',
     task_type: 'remote_agent',
     remote_session_id: 'remote-session-1',
+  }))
+})
+
+function makeTask(
+  overrides: Partial<TaskState> & Pick<TaskState, 'id' | 'type'>,
+): TaskState {
+  return {
+    status: 'running',
+    description: 'Background work',
+    startTime: 1,
+    outputFile: '/tmp/task.output',
+    outputOffset: 0,
+    notified: false,
+    ...overrides,
+  } as unknown as TaskState
+}
+
+function makeHarness() {
+  let state = { tasks: {} } as unknown as AppState
+  return {
+    get state() {
+      return state
+    },
+    setAppState(updater: (prev: AppState) => AppState) {
+      state = updater(state)
+    },
+  }
+}
+
+test('emits a task_started event for a main-thread shell task', () => {
+  const harness = makeHarness()
+  const task = makeTask({
+    id: 'main-shell-task',
+    type: 'local_bash',
+    toolUseId: 'main-shell-tool',
+  })
+
+  registerTask(task, harness.setAppState)
+
+  expect(harness.state.tasks['main-shell-task']).toBe(task)
+  expect(drainSdkEvents()).toContainEqual(expect.objectContaining({
+    type: 'system',
+    subtype: 'task_started',
+    task_id: 'main-shell-task',
+    tool_use_id: 'main-shell-tool',
+    task_type: 'local_bash',
+  }))
+})
+
+test('does not expose a subagent-owned shell task as a session background task', () => {
+  const harness = makeHarness()
+  const task = makeTask({
+    id: 'subagent-shell-task',
+    type: 'local_bash',
+    toolUseId: 'subagent-shell-tool',
+    agentId: 'subagent-1',
+  })
+
+  registerTask(task, harness.setAppState)
+
+  expect(harness.state.tasks['subagent-shell-task']).toBe(task)
+  expect(drainSdkEvents()).toEqual([])
+})
+
+test('still exposes a local agent task in the session activity stream', () => {
+  const harness = makeHarness()
+  const task = makeTask({
+    id: 'subagent-task',
+    type: 'local_agent',
+    toolUseId: 'agent-tool',
+    agentId: 'subagent-task',
+  })
+
+  registerTask(task, harness.setAppState)
+
+  expect(drainSdkEvents()).toContainEqual(expect.objectContaining({
+    type: 'system',
+    subtype: 'task_started',
+    task_id: 'subagent-task',
+    tool_use_id: 'agent-tool',
+    task_type: 'local_agent',
   }))
 })

--- a/src/utils/task/framework.ts
+++ b/src/utils/task/framework.ts
@@ -101,6 +101,10 @@ export function registerTask(task: TaskState, setAppState: SetAppState): void {
   // Replacement (resume) — not a new start. Skip to avoid double-emit.
   if (isReplacement) return
 
+  // Subagent shell activity is already grouped under its Agent tool call.
+  // Exposing it as a session task leaves the parent Activity row unowned.
+  if (task.type === 'local_bash' && task.agentId) return
+
   enqueueSdkEvent({
     type: 'system',
     subtype: 'task_started',


### PR DESCRIPTION
## TL;DR

修复了子 Agent 的后台命令出现在主会话 Activity 面板里，点击停止后又报“找不到任务”的问题。

Fixes #1142

## 改动点

- 带 `agentId` 的 `local_bash` 任务不再向主会话发送启动事件。
- 停止这类任务时，不再向主会话写入孤立的完成或失败状态。
- 主会话自己的命令和子 Agent 整体任务仍保持原来的展示与停止行为。

## 测试

- 相关单元测试全部通过（6/6 passed）。
- 覆盖主任务兼容、子 Agent 任务隔离和停止事件处理。
- 当前 GitHub Actions 中，本次改动覆盖的 `framework.test.ts` 已通过；服务端与覆盖率检查被同一 CI 环境问题挡住（缺少 adapter 依赖和 ripgrep）。另外，CLI core 门禁需要维护者添加 `allow-cli-core-change` 标签并批准。