### PR TITLE
fix(desktop): refresh expanded workspace folders

### DIFF
--- a/desktop/src/components/workspace/WorkspacePanel.test.tsx
+++ b/desktop/src/components/workspace/WorkspacePanel.test.tsx
@@ -3124,4 +3124,156 @@ describe('WorkspacePanel', () => {
     expect(view.queryByText('cached')).toBeNull()
     expect(view.getByTestId('workspace-preview-content').getAttribute('aria-busy')).toBe('false')
   })
+
+  it('refreshes root and expanded subdirectories in all-files view and displays new files', async () => {
+    const sessionId = 'session-refresh-expanded-tree'
+
+    await setWorkspaceState((state) => ({
+      ...state,
+      panelBySession: {
+        ...state.panelBySession,
+        [sessionId]: { isOpen: true, activeView: 'all', hasUserSelectedView: true },
+      },
+      statusBySession: {
+        ...state.statusBySession,
+        [sessionId]: {
+          state: 'ok',
+          workDir: '/repo',
+          repoName: 'repo',
+          branch: 'main',
+          isGitRepo: true,
+          changedFiles: [],
+        },
+      },
+      expandedPathsBySession: {
+        ...state.expandedPathsBySession,
+        [sessionId]: ['src'],
+      },
+      treeBySessionPath: {
+        ...state.treeBySessionPath,
+        [sessionId]: {
+          '': {
+            state: 'ok',
+            path: '',
+            entries: [{ name: 'src', path: 'src', isDirectory: true }],
+          },
+          src: {
+            state: 'ok',
+            path: 'src',
+            entries: [{ name: 'a.ts', path: 'src/a.ts', isDirectory: false }],
+          },
+        },
+      },
+    }))
+
+    getMocks().getWorkspaceTreeMock.mockImplementation(async (_sessionId: string, path = '') => {
+      if (path === '') {
+        return {
+          state: 'ok',
+          path: '',
+          entries: [{ name: 'src', path: 'src', isDirectory: true }],
+        }
+      }
+      if (path === 'src') {
+        return {
+          state: 'ok',
+          path: 'src',
+          entries: [
+            { name: 'a.ts', path: 'src/a.ts', isDirectory: false },
+            { name: 'b.ts', path: 'src/b.ts', isDirectory: false },
+          ],
+        }
+      }
+      return { state: 'ok', path, entries: [] }
+    })
+
+    const view = await renderPanel(sessionId)
+
+    expect(await view.findByText('a.ts')).toBeTruthy()
+    expect(view.queryByText('b.ts')).toBeNull()
+
+    const refreshButton = view.getByRole('button', { name: /Refresh|刷新/ })
+    await clickElement(refreshButton)
+
+    await waitFor(() => {
+      expect(getMocks().getWorkspaceTreeMock).toHaveBeenCalledWith(sessionId, '')
+      expect(getMocks().getWorkspaceTreeMock).toHaveBeenCalledWith(sessionId, 'src')
+    })
+    expect(await view.findByText('b.ts')).toBeTruthy()
+  })
+
+  it('re-searches and refreshes workspace tree when refresh is clicked in search mode', async () => {
+    const sessionId = 'session-refresh-search'
+
+    await setWorkspaceState((state) => ({
+      ...state,
+      panelBySession: {
+        ...state.panelBySession,
+        [sessionId]: { isOpen: true, activeView: 'all', hasUserSelectedView: true },
+      },
+      statusBySession: {
+        ...state.statusBySession,
+        [sessionId]: {
+          state: 'ok',
+          workDir: '/repo',
+          repoName: 'repo',
+          branch: 'main',
+          isGitRepo: true,
+          changedFiles: [],
+        },
+      },
+      expandedPathsBySession: {
+        ...state.expandedPathsBySession,
+        [sessionId]: ['src'],
+      },
+      treeBySessionPath: {
+        ...state.treeBySessionPath,
+        [sessionId]: {
+          '': {
+            state: 'ok',
+            path: '',
+            entries: [{ name: 'src', path: 'src', isDirectory: true }],
+          },
+          src: {
+            state: 'ok',
+            path: 'src',
+            entries: [{ name: 'app.ts', path: 'src/app.ts', isDirectory: false }],
+          },
+        },
+      },
+    }))
+
+    getMocks().searchWorkspaceMock.mockResolvedValue({
+      state: 'ok',
+      query: 'app',
+      truncated: false,
+      entries: [{ name: 'app.ts', path: 'src/app.ts', isDirectory: false }],
+    })
+    getMocks().getWorkspaceTreeMock.mockImplementation(async (_sessionId: string, path = '') => ({
+      state: 'ok',
+      path,
+      entries: path === ''
+        ? [{ name: 'src', path: 'src', isDirectory: true }]
+        : [{ name: 'app.ts', path: 'src/app.ts', isDirectory: false }],
+    }))
+
+    const view = await renderPanel(sessionId)
+
+    fireEvent.change(view.getByPlaceholderText('Search all files...'), {
+      target: { value: 'app' },
+    })
+
+    expect(await view.findByText('app.ts')).toBeTruthy()
+    getMocks().getWorkspaceTreeMock.mockClear()
+    getMocks().searchWorkspaceMock.mockClear()
+
+    const refreshButton = view.getByRole('button', { name: /Refresh|刷新/ })
+    await clickElement(refreshButton)
+
+    await waitFor(() => {
+      expect(getMocks().getWorkspaceTreeMock).toHaveBeenCalledWith(sessionId, '')
+      expect(getMocks().getWorkspaceTreeMock).toHaveBeenCalledWith(sessionId, 'src')
+      expect(getMocks().searchWorkspaceMock).toHaveBeenCalledWith(sessionId, 'app')
+    })
+  })
 })

--- a/desktop/src/components/workspace/WorkspacePanel.tsx
+++ b/desktop/src/components/workspace/WorkspacePanel.tsx
@@ -1274,6 +1274,7 @@ export function WorkspacePanel({ sessionId, embedded = false, forceVisible = fal
   const setActiveView = useWorkspacePanelStore((state) => state.setActiveView)
   const loadStatus = useWorkspacePanelStore((state) => state.loadStatus)
   const loadTree = useWorkspacePanelStore((state) => state.loadTree)
+  const refreshWorkspaceTree = useWorkspacePanelStore((state) => state.refreshWorkspaceTree)
   const toggleTreeNode = useWorkspacePanelStore((state) => state.toggleTreeNode)
   const openPreview = useWorkspacePanelStore((state) => state.openPreview)
   const closePreview = useWorkspacePanelStore((state) => state.closePreview)
@@ -1444,10 +1445,11 @@ export function WorkspacePanel({ sessionId, embedded = false, forceVisible = fal
     if (activePreviewTab) {
       void openPreview(sessionId, activePreviewTab.path, activePreviewTab.kind)
     }
+    if (navigatorView === 'all') {
+      void refreshWorkspaceTree(sessionId)
+    }
     if (hasWorkspaceSearch) {
       setWorkspaceSearchRevision((revision) => revision + 1)
-    } else if (navigatorView === 'all') {
-      void loadTree(sessionId, '')
     }
   }
 

--- a/desktop/src/stores/workspacePanelStore.test.ts
+++ b/desktop/src/stores/workspacePanelStore.test.ts
@@ -895,4 +895,192 @@ describe('workspacePanelStore', () => {
     expect(state.errors.previewRefreshStateByTabId['session-clear::file:src/a.ts']).toBeUndefined()
     expect(state.errors.previewRefreshStateByTabId['session-reset::file:src/b.ts']).toBeUndefined()
   })
+
+  it('refreshes root and all expanded directories for a session', async () => {
+    mocks.getWorkspaceTreeMock
+      .mockResolvedValueOnce({
+        state: 'ok',
+        path: '',
+        entries: [{ name: 'src', path: 'src', isDirectory: true }],
+      })
+      .mockResolvedValueOnce({
+        state: 'ok',
+        path: 'src',
+        entries: [{ name: 'components', path: 'src/components', isDirectory: true }],
+      })
+      .mockResolvedValueOnce({
+        state: 'ok',
+        path: 'src/components',
+        entries: [{ name: 'Button.tsx', path: 'src/components/Button.tsx', isDirectory: false }],
+      })
+
+    useWorkspacePanelStore.setState({
+      expandedPathsBySession: {
+        'session-refresh-tree': ['src', 'src/components'],
+      },
+    })
+
+    await useWorkspacePanelStore.getState().refreshWorkspaceTree('session-refresh-tree')
+
+    expect(mocks.getWorkspaceTreeMock).toHaveBeenCalledTimes(3)
+    expect(mocks.getWorkspaceTreeMock).toHaveBeenCalledWith('session-refresh-tree', '')
+    expect(mocks.getWorkspaceTreeMock).toHaveBeenCalledWith('session-refresh-tree', 'src')
+    expect(mocks.getWorkspaceTreeMock).toHaveBeenCalledWith('session-refresh-tree', 'src/components')
+    expect(useWorkspacePanelStore.getState().treeBySessionPath['session-refresh-tree']).toMatchObject({
+      '': { entries: [{ path: 'src' }] },
+      src: { entries: [{ path: 'src/components' }] },
+      'src/components': { entries: [{ path: 'src/components/Button.tsx' }] },
+    })
+  })
+
+  it('retains existing tree cache while refresh calls are pending', async () => {
+    const rootDeferred = deferred<{ state: 'ok'; path: string; entries: Array<{ name: string; path: string; isDirectory: boolean }> }>()
+    const srcDeferred = deferred<{ state: 'ok'; path: string; entries: Array<{ name: string; path: string; isDirectory: boolean }> }>()
+
+    useWorkspacePanelStore.setState({
+      expandedPathsBySession: {
+        'session-pending-cache': ['src'],
+      },
+      treeBySessionPath: {
+        'session-pending-cache': {
+          '': {
+            state: 'ok',
+            path: '',
+            entries: [{ name: 'src', path: 'src', isDirectory: true }],
+          },
+          src: {
+            state: 'ok',
+            path: 'src',
+            entries: [{ name: 'old.ts', path: 'src/old.ts', isDirectory: false }],
+          },
+        },
+      },
+    })
+
+    mocks.getWorkspaceTreeMock.mockImplementation(async (_sessionId: string, path: string) => {
+      if (path === '') return rootDeferred.promise
+      if (path === 'src') return srcDeferred.promise
+      return { state: 'ok', path, entries: [] }
+    })
+
+    const refreshPromise = useWorkspacePanelStore.getState().refreshWorkspaceTree('session-pending-cache')
+
+    expect(useWorkspacePanelStore.getState().treeBySessionPath['session-pending-cache']?.['']?.entries).toEqual([
+      { name: 'src', path: 'src', isDirectory: true },
+    ])
+    expect(useWorkspacePanelStore.getState().treeBySessionPath['session-pending-cache']?.['src']?.entries).toEqual([
+      { name: 'old.ts', path: 'src/old.ts', isDirectory: false },
+    ])
+
+    rootDeferred.resolve({
+      state: 'ok',
+      path: '',
+      entries: [{ name: 'src', path: 'src', isDirectory: true }],
+    })
+    srcDeferred.resolve({
+      state: 'ok',
+      path: 'src',
+      entries: [{ name: 'new.ts', path: 'src/new.ts', isDirectory: false }],
+    })
+
+    await refreshPromise
+
+    expect(useWorkspacePanelStore.getState().treeBySessionPath['session-pending-cache']?.['src']?.entries).toEqual([
+      { name: 'new.ts', path: 'src/new.ts', isDirectory: false },
+    ])
+  })
+
+  it('preserves other directories and expanded state when a refreshed directory returns an error', async () => {
+    useWorkspacePanelStore.setState({
+      expandedPathsBySession: {
+        'session-error-tree': ['src', 'docs'],
+      },
+      treeBySessionPath: {
+        'session-error-tree': {
+          '': {
+            state: 'ok',
+            path: '',
+            entries: [
+              { name: 'src', path: 'src', isDirectory: true },
+              { name: 'docs', path: 'docs', isDirectory: true },
+            ],
+          },
+          src: {
+            state: 'ok',
+            path: 'src',
+            entries: [{ name: 'index.ts', path: 'src/index.ts', isDirectory: false }],
+          },
+          docs: {
+            state: 'ok',
+            path: 'docs',
+            entries: [{ name: 'readme.md', path: 'docs/readme.md', isDirectory: false }],
+          },
+        },
+      },
+    })
+
+    mocks.getWorkspaceTreeMock.mockImplementation(async (_sessionId: string, path: string) => {
+      if (path === '') {
+        return {
+          state: 'ok',
+          path: '',
+          entries: [
+            { name: 'src', path: 'src', isDirectory: true },
+            { name: 'docs', path: 'docs', isDirectory: true },
+          ],
+        }
+      }
+      if (path === 'src') {
+        return {
+          state: 'ok',
+          path: 'src',
+          entries: [{ name: 'index.ts', path: 'src/index.ts', isDirectory: false }, { name: 'app.ts', path: 'src/app.ts', isDirectory: false }],
+        }
+      }
+      if (path === 'docs') {
+        return {
+          state: 'error',
+          path: 'docs',
+          error: 'Access denied',
+        }
+      }
+      return { state: 'ok', path, entries: [] }
+    })
+
+    await useWorkspacePanelStore.getState().refreshWorkspaceTree('session-error-tree')
+
+    expect(useWorkspacePanelStore.getState().expandedPathsBySession['session-error-tree']).toEqual(['src', 'docs'])
+    expect(useWorkspacePanelStore.getState().treeBySessionPath['session-error-tree']?.['src']?.entries).toHaveLength(2)
+    expect(useWorkspacePanelStore.getState().errors.treeBySessionPath['session-error-tree::docs']).toBe('Access denied')
+  })
+
+  it('ensures the latest response wins when refreshWorkspaceTree is called concurrently', async () => {
+    const firstRoot = deferred<{ state: 'ok'; path: string; entries: Array<{ name: string; path: string; isDirectory: boolean }> }>()
+    const secondRoot = deferred<{ state: 'ok'; path: string; entries: Array<{ name: string; path: string; isDirectory: boolean }> }>()
+
+    mocks.getWorkspaceTreeMock
+      .mockReturnValueOnce(firstRoot.promise)
+      .mockReturnValueOnce(secondRoot.promise)
+
+    const firstRefresh = useWorkspacePanelStore.getState().refreshWorkspaceTree('session-concurrent-refresh')
+    const secondRefresh = useWorkspacePanelStore.getState().refreshWorkspaceTree('session-concurrent-refresh')
+
+    secondRoot.resolve({
+      state: 'ok',
+      path: '',
+      entries: [{ name: 'latest.ts', path: 'latest.ts', isDirectory: false }],
+    })
+    await secondRefresh
+
+    firstRoot.resolve({
+      state: 'ok',
+      path: '',
+      entries: [{ name: 'stale.ts', path: 'stale.ts', isDirectory: false }],
+    })
+    await firstRefresh
+
+    expect(useWorkspacePanelStore.getState().treeBySessionPath['session-concurrent-refresh']?.['']?.entries).toEqual([
+      { name: 'latest.ts', path: 'latest.ts', isDirectory: false },
+    ])
+  })
 })

--- a/desktop/src/stores/workspacePanelStore.ts
+++ b/desktop/src/stores/workspacePanelStore.ts
@@ -95,6 +95,7 @@ type WorkspacePanelStore = {
   setActiveView: (sessionId: string, view: WorkspacePanelView) => void
   loadStatus: (sessionId: string) => Promise<void>
   loadTree: (sessionId: string, path?: string) => Promise<void>
+  refreshWorkspaceTree: (sessionId: string) => Promise<void>
   toggleTreeNode: (sessionId: string, path: string) => Promise<void>
   openPreview: (
     sessionId: string,
@@ -481,6 +482,12 @@ export const useWorkspacePanelStore = create<WorkspacePanelStore>((set, get) => 
     if (shouldLoad) {
       await get().loadTree(sessionId, path)
     }
+  },
+
+  refreshWorkspaceTree: async (sessionId) => {
+    const expanded = get().expandedPathsBySession[sessionId] ?? []
+    const pathsToRefresh = Array.from(new Set(['', ...expanded]))
+    await Promise.all(pathsToRefresh.map((path) => get().loadTree(sessionId, path)))
   },
 
   openPreview: async (sessionId, path, kind, origin, reveal) => {


### PR DESCRIPTION
## Summary

### TL;DR

修复工作区点击刷新后，只更新根目录、已展开子目录仍显示旧文件的问题。

Fixes #1175

## 改动点

1. 刷新时同时重新加载根目录和当前展开的目录。
2. 保留已有内容和展开状态，单个目录失败不影响其他目录。
3. 搜索状态下同时刷新文件树和搜索结果，连续刷新仍以最后一次结果为准。

## 测试

- `workspacePanelStore.test.ts`：33/33 通过。
- `WorkspacePanel.test.tsx`：50/50 通过。
- TypeScript `--noEmit` 和 `git diff --check`：通过。
- 两个变更源文件的定向 V8 覆盖率：整体 94.6%，`WorkspacePanel.tsx` 95.57%，`workspacePanelStore.ts` 92.03%。
- `bun run check:impact`：通过，选中了 desktop 和 coverage 检查。
- `bun run check:desktop`：lint/类型检查通过；完整测试 3890 通过、13 失败、2 跳过。失败来自 Windows symlink 权限、可在干净 `origin/main` 复现的主题测试，以及一条无关聊天旧测试；测试阶段失败后未执行 build。
- `bun run check:coverage`：本机完整门禁未通过；上述环境/基线失败导致 desktop coverage 未产出。定向覆盖率已单独验证。
- Live model：未运行（fork 无 provider，也不涉及模型路径）。

## Feature Quality Contract

- Changed surface: desktop
- Tests added or updated:
  - Store tests cover root and expanded-directory refresh, pending cache, partial errors, and concurrent refresh ordering.
  - Component tests cover newly added files appearing after refresh and search mode refreshing both tree and results.
- Coverage evidence:
  - Targeted V8 coverage: 83 tests passed; 94.6% lines/statements across the two changed source files.
  - Local full report: `artifacts/coverage/2026-08-03T10-43-14-832Z/coverage-report.md` (not committed); full collection was blocked by the unrelated failures listed above.
- E2E / live-model evidence:
  - Not run; this change stays within the existing desktop store/component boundary and is covered by component interaction tests.
- Known risk / rollback:
  - Refresh sends one request for the root and each expanded directory. Very large expanded trees may create a short burst of IPC requests.
  - Rollback is reverting commit `b20ab77e`.

## Verification

- [x] I ran the relevant local checks, or explained why they do not apply.
- [x] I added or updated same-area tests for every production behavior change.
- [x] I ran the checks selected by `bun run check:impact`; this Draft does not claim full validation because the unrelated Windows baseline failures are documented above.
- [x] New executable lines are covered by the targeted tests and the changed source files exceed 90% line coverage.
- [x] Pass/fail/skip counts and the local coverage report path are summarized above.
- [x] No cross-boundary or provider contract changed; live-model testing does not apply.

## Risk

- [x] This PR does not touch CLI core paths.
- [x] Production code changes include matching tests.
- [x] This PR does not change coverage baselines or thresholds.
- [x] This PR does not change quarantine policy.
- [x] This PR does not touch provider/runtime behavior.
