### PR TITLE
fix(ci): count Bun test groups when summary is missing

### DIFF
--- a/scripts/quality-gate/coverage.test.ts
+++ b/scripts/quality-gate/coverage.test.ts
@@ -123,6 +123,24 @@ describe('coverage gate helpers', () => {
     expect(parseBunTestFileCount('process terminated before summary')).toBeNull()
   })
 
+  test('counts unique GitHub Actions test groups when Bun omits the summary', () => {
+    const output = [
+      '39 tests failed:',
+      '::group::src/bridge/inboundAttachments.test.ts:',
+      '::endgroup::',
+      '::group::src/cli/structuredIO.test.ts:',
+      '::endgroup::',
+      '::group::src/bridge/inboundAttachments.test.ts:',
+      '::endgroup::',
+      '::group::src\\bridge\\inboundAttachments.test.ts:',
+      '::endgroup::',
+      '::group::coverage summary:',
+      '::endgroup::',
+    ].join('\r\n')
+
+    expect(parseBunTestFileCount(output)).toBe(2)
+  })
+
   test('rejects empty aggregate coverage summaries', () => {
     expect(hasUsableCoverageSummary({
       lines: { total: 0, covered: 0, pct: 100 },

--- a/scripts/quality-gate/coverage.ts
+++ b/scripts/quality-gate/coverage.ts
@@ -349,7 +349,15 @@ function isUsableLcovRecord(record: LcovRecord) {
 
 export function parseBunTestFileCount(output: string) {
   const match = output.match(/Ran \d+ tests? across (\d+) files?\./)
-  return match ? Number(match[1]) : null
+  if (match) return Number(match[1])
+
+  const groupedTestFiles = new Set<string>()
+  for (const group of output.matchAll(/^::group::(.+):\r?$/gm)) {
+    const file = group[1]?.trim()
+    if (file && TEST_FILE_PATTERN.test(file)) groupedTestFiles.add(file.replace(/\\/g, '/'))
+  }
+
+  return groupedTestFiles.size > 0 ? groupedTestFiles.size : null
 }
 
 export function buildRootCoverageCommand(outputDir: string, serverFiles: string[]) {


### PR DESCRIPTION
## TL;DR

Fixes the coverage gate reporting zero discovered root test files when Bun finishes coverage with test failures and omits its normal summary line.

## Changes

- Keep the normal `Ran ... across ... files.` summary as the first choice.
- Fall back to unique GitHub Actions test-file groups when the summary is missing.
- Normalize path separators and ignore non-test groups.
- Keep missing or incomplete output fail-closed.

## Tests

- Regression test passes for failed output, duplicate groups, CRLF, mixed path separators, and non-test groups.
- Replayed the PR #1180 root coverage log: 269 test files detected.
- Real Ubuntu CI no longer reports `0/269`; it now reaches the next accurate failure: the failed root run produced no usable LCOV records.
- `git diff --check` passed.
- Full Windows coverage is not green because of existing host limits (command length, symlink permissions, and unrelated desktop failures); the targeted parser test passes.

Closes #1182