### PR TITLE
fix(ci): stabilize root coverage checks

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -262,6 +262,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep && rg --version
       - name: Install root dependencies
         run: bun install --frozen-lockfile
       - name: Install desktop dependencies

--- a/scripts/pr/pr-quality-workflow.test.ts
+++ b/scripts/pr/pr-quality-workflow.test.ts
@@ -79,6 +79,20 @@ describe('PR quality workflow', () => {
     expect(workflow).toContain('retention-days: 14')
   })
 
+  test('installs ripgrep only for the coverage lane', () => {
+    const workflow = readFileSync('.github/workflows/pr-quality.yml', 'utf8')
+    const jobs = workflowJobs(workflow)
+    const coverageSteps = jobs['coverage-checks'].steps ?? []
+    const ripgrepSteps = Object.values(jobs)
+      .flatMap(job => job.steps ?? [])
+      .filter(step => step.name === 'Install ripgrep')
+
+    expect(ripgrepSteps).toHaveLength(1)
+    expect(coverageSteps.find(step => step.name === 'Install ripgrep')?.run).toBe(
+      'sudo apt-get install -y ripgrep && rg --version',
+    )
+  })
+
   test('installs and validates the isolated React site for docs changes', () => {
     const workflow = readFileSync('.github/workflows/pr-quality.yml', 'utf8')
     const jobs = workflowJobs(workflow)

--- a/src/server/__tests__/conversations.test.ts
+++ b/src/server/__tests__/conversations.test.ts
@@ -2044,6 +2044,7 @@ describe('WebSocket Chat Integration', () => {
   }
   const originalCliPath = process.env.CLAUDE_CLI_PATH
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const originalProviderServerPort = ProviderService.getServerPort()
 
   beforeAll(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-conv-'))
@@ -2067,6 +2068,7 @@ describe('WebSocket Chat Integration', () => {
     server?.stop(true)
     const { stopServerRuntimeForShutdown } = await import('../index.js')
     await stopServerRuntimeForShutdown()
+    ProviderService.setServerPort(originalProviderServerPort)
     if (tmpDir) {
       await rmWithRetry(tmpDir)
     }

--- a/src/services/api/client.test.ts
+++ b/src/services/api/client.test.ts
@@ -1,16 +1,20 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { GROK_OAUTH_DUMMY_KEY } from '../grokAuth/fetch.js'
 
-mock.module('src/utils/http.js', () => ({
-  getAuthHeaders: mock(() => ({})),
-  getMCPUserAgent: mock(() => 'client-test-agent'),
-  getUserAgent: mock(() => 'client-test-agent'),
-  getWebFetchUserAgent: mock(() => 'client-test-agent'),
-  withOAuth401Retry: mock(async <T>(fn: () => Promise<T>) => fn()),
-}))
+const httpModule = await import('src/utils/http.js')
+
+spyOn(httpModule, 'getAuthHeaders').mockImplementation(() => ({}))
+spyOn(httpModule, 'getMCPUserAgent').mockImplementation(() => 'client-test-agent')
+spyOn(httpModule, 'getUserAgent').mockImplementation(() => 'client-test-agent')
+spyOn(httpModule, 'getWebFetchUserAgent').mockImplementation(() => 'client-test-agent')
+spyOn(httpModule, 'withOAuth401Retry').mockImplementation(async <T>(fn: () => Promise<T>) => fn())
+
+afterAll(() => {
+  mock.restore()
+})
 
 describe('resolveAnthropicClientApiKey', () => {
   test('does not inherit a local api key when a provider auth token is explicit', async () => {

--- a/src/tools/shared/spawnMultiAgent.callsite.test.ts
+++ b/src/tools/shared/spawnMultiAgent.callsite.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import type { AppState } from '../../state/AppState.js'
 import type { ToolUseContext } from '../../Tool.js'
 import type {
@@ -38,46 +38,40 @@ const startInProcessTeammateMock = mock((_config: unknown) => {})
 const execFileNoThrowModule = await import('../../utils/execFileNoThrow.js')
 const taskFrameworkModule = await import('../../utils/task/framework.js')
 const teamHelpersModule = await import('../../utils/swarm/teamHelpers.js')
+const backendRegistryModule = await import('../../utils/swarm/backends/registry.js')
+const backendDetectionModule = await import('../../utils/swarm/backends/detection.js')
+const teammateLayoutModule = await import('../../utils/swarm/teammateLayoutManager.js')
+const inProcessRunnerModule = await import('../../utils/swarm/inProcessRunner.js')
+const spawnInProcessModule = await import('../../utils/swarm/spawnInProcess.js')
+const teammateMailboxModule = await import('../../utils/teammateMailbox.js')
 const mutateTeamFileAsyncActual = teamHelpersModule.mutateTeamFileAsync
 const readTeamFileAsyncActual = teamHelpersModule.readTeamFileAsync
 
-mock.module('../../utils/swarm/backends/registry.js', () => ({
-  detectAndGetBackend: async () => ({
+function installTestDoubles(): void {
+  spyOn(backendRegistryModule, 'detectAndGetBackend').mockImplementation(async () => ({
     backend: { type: 'tmux' },
     needsIt2Setup: false,
-  }),
-  getBackendByType: () => ({ killPane: async () => {} }),
-  isInProcessEnabled: () => spawnMode === 'in-process',
-  markInProcessFallback: () => {},
-  resetBackendDetection: () => {},
-}))
+  }) as any)
+  spyOn(backendRegistryModule, 'getBackendByType').mockImplementation(() => ({ killPane: async () => {} }) as any)
+  spyOn(backendRegistryModule, 'isInProcessEnabled').mockImplementation(() => spawnMode === 'in-process')
+  spyOn(backendRegistryModule, 'markInProcessFallback').mockImplementation(() => {})
+  spyOn(backendRegistryModule, 'resetBackendDetection').mockImplementation(() => {})
 
-mock.module('../../utils/swarm/backends/detection.js', () => ({
-  isTmuxAvailable: async () => true,
-}))
+  spyOn(backendDetectionModule, 'isTmuxAvailable').mockImplementation(async () => true)
 
-mock.module('../../utils/swarm/teammateLayoutManager.js', () => ({
-  assignTeammateColor: () => 'blue',
-  createTeammatePaneInSwarmView: async () => ({
+  spyOn(teammateLayoutModule, 'assignTeammateColor').mockImplementation(() => 'blue')
+  spyOn(teammateLayoutModule, 'createTeammatePaneInSwarmView').mockImplementation(async () => ({
     paneId: '%split',
     isFirstTeammate: false,
-  }),
-  enablePaneBorderStatus: async () => {},
-  isInsideTmux: async () => true,
-  sendCommandToPane: sendCommandToPaneMock,
-}))
+  }) as any)
+  spyOn(teammateLayoutModule, 'enablePaneBorderStatus').mockImplementation(async () => {})
+  spyOn(teammateLayoutModule, 'isInsideTmux').mockImplementation(() => true)
+  spyOn(teammateLayoutModule, 'sendCommandToPane').mockImplementation(sendCommandToPaneMock)
 
-mock.module('../../utils/swarm/inProcessRunner.js', () => ({
-  startInProcessTeammate: startInProcessTeammateMock,
-}))
+  spyOn(inProcessRunnerModule, 'startInProcessTeammate').mockImplementation(startInProcessTeammateMock as any)
+  spyOn(spawnInProcessModule, 'spawnInProcessTeammate').mockImplementation(spawnInProcessTeammateMock as any)
 
-mock.module('../../utils/swarm/spawnInProcess.js', () => ({
-  spawnInProcessTeammate: spawnInProcessTeammateMock,
-}))
-
-mock.module('../../utils/swarm/teamHelpers.js', () => ({
-  ...teamHelpersModule,
-  mutateTeamFileAsync: async (
+  spyOn(teamHelpersModule, 'mutateTeamFileAsync').mockImplementation(async (
     teamName: string,
     mutate: (teamFile: { members: unknown[] }) => void,
   ) => {
@@ -85,33 +79,24 @@ mock.module('../../utils/swarm/teamHelpers.js', () => ({
       return mutateTeamFileAsyncActual(teamName, mutate)
     }
     mutate({ members: [] })
-  },
-  readTeamFileAsync: async (teamName: string) =>
+  })
+  spyOn(teamHelpersModule, 'readTeamFileAsync').mockImplementation(async (teamName: string) =>
     teamName === 'review-team'
       ? null
-      : readTeamFileAsyncActual(teamName),
-  sanitizeAgentName: (name: string) => name.replaceAll('@', '-'),
-  sanitizeName: (name: string) =>
-    name.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase(),
-}))
+      : readTeamFileAsyncActual(teamName))
+  spyOn(teamHelpersModule, 'sanitizeAgentName').mockImplementation((name: string) => name.replaceAll('@', '-'))
+  spyOn(teamHelpersModule, 'sanitizeName').mockImplementation((name: string) =>
+  name.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase())
 
-mock.module('../../utils/task/framework.js', () => ({
-  ...taskFrameworkModule,
-  registerTask: () => {},
-}))
-
-mock.module('../../utils/teammateMailbox.js', () => ({
-  writeToMailbox: async () => {},
-}))
-
-mock.module('../../utils/execFileNoThrow.js', () => ({
-  ...execFileNoThrowModule,
-  execFileNoThrow: execFileNoThrowMock,
-}))
+  spyOn(taskFrameworkModule, 'registerTask').mockImplementation(() => {})
+  spyOn(teammateMailboxModule, 'writeToMailbox').mockImplementation(async () => {})
+  spyOn(execFileNoThrowModule, 'execFileNoThrow').mockImplementation(execFileNoThrowMock as any)
+}
 
 const { spawnTeammate } = await import('./spawnMultiAgent.js')
 
 beforeEach(() => {
+  installTestDoubles()
   delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
   spawnMode = 'split-pane'
   paneCommands.length = 0
@@ -122,7 +107,8 @@ beforeEach(() => {
   startInProcessTeammateMock.mockClear()
 })
 
-afterAll(() => {
+afterEach(() => {
+  mock.restore()
   if (originalSubagentModel === undefined) {
     delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
   } else {

--- a/src/utils/managedEnv.test.ts
+++ b/src/utils/managedEnv.test.ts
@@ -3,20 +3,23 @@ import * as fs from 'fs/promises'
 import * as os from 'os'
 import * as path from 'path'
 
+import { MANAGED_PROVIDER_ENV_KEYS } from '../server/services/providerRuntimeEnv.js'
+import { resetModelStringsForTestingOnly } from '../bootstrap/state.js'
 import { applySafeConfigEnvironmentVariables } from './managedEnv.js'
+import { resetSettingsCache } from './settings/settingsCache.js'
 
 let tmpDir: string
-const originalEnv = {
-  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
-  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST,
-  CC_HAHA_LOCAL_ACCESS_TOKEN: process.env.CC_HAHA_LOCAL_ACCESS_TOKEN,
-  ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
-  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-  ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
-  ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
-}
+const TEST_ENV_KEYS = [
+  'CLAUDE_CONFIG_DIR',
+  'CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST',
+  'CC_HAHA_LOCAL_ACCESS_TOKEN',
+  ...MANAGED_PROVIDER_ENV_KEYS,
+] as const
+const originalEnv = Object.fromEntries(
+  TEST_ENV_KEYS.map(key => [key, process.env[key]]),
+) as Record<(typeof TEST_ENV_KEYS)[number], string | undefined>
 
-function restoreEnv(key: keyof typeof originalEnv): void {
+function restoreEnv(key: (typeof TEST_ENV_KEYS)[number]): void {
   const value = originalEnv[key]
   if (value === undefined) {
     delete process.env[key]
@@ -33,13 +36,9 @@ async function writeJson(filePath: string, value: unknown): Promise<void> {
 describe('managedEnv', () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'managed-env-'))
+    for (const key of TEST_ENV_KEYS) delete process.env[key]
     process.env.CLAUDE_CONFIG_DIR = tmpDir
-    delete process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
-    delete process.env.CC_HAHA_LOCAL_ACCESS_TOKEN
-    delete process.env.ANTHROPIC_BASE_URL
-    delete process.env.ANTHROPIC_API_KEY
-    delete process.env.ANTHROPIC_AUTH_TOKEN
-    delete process.env.ANTHROPIC_MODEL
+    resetSettingsCache()
   })
 
   afterEach(async () => {
@@ -47,13 +46,9 @@ describe('managedEnv', () => {
       .then((mod) => mod.stopStandaloneProviderProxyForTests?.())
       .catch(() => {})
     await fs.rm(tmpDir, { recursive: true, force: true })
-    restoreEnv('CLAUDE_CONFIG_DIR')
-    restoreEnv('CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST')
-    restoreEnv('CC_HAHA_LOCAL_ACCESS_TOKEN')
-    restoreEnv('ANTHROPIC_BASE_URL')
-    restoreEnv('ANTHROPIC_API_KEY')
-    restoreEnv('ANTHROPIC_AUTH_TOKEN')
-    restoreEnv('ANTHROPIC_MODEL')
+    for (const key of TEST_ENV_KEYS) restoreEnv(key)
+    resetSettingsCache()
+    resetModelStringsForTestingOnly()
   })
 
   test('starts a standalone provider proxy for CLI-only OpenAI-compatible providers', async () => {


### PR DESCRIPTION
## TL;DR

修复 PR 覆盖率任务缺少 ripgrep，以及多组测试共用全局 mock、环境变量和端口状态后相互影响的问题。

这项改动用于验证并解除 #1180 和 #1183 共同遇到的 coverage-checks 阻塞。

## 改动点

1. coverage-checks 安装并验证 ripgrep，避免搜索相关测试因 CI 环境缺少 `rg` 连锁失败。
2. 把 HTTP 和 Agent Teams 测试的模块替身限制在测试作用域内，结束后恢复，避免污染后续测试。
3. managedEnv 测试恢复 provider 环境、设置缓存和模型默认值；WebSocket 集成测试恢复 ProviderService 端口。
4. 增加 workflow 契约测试，保证 ripgrep 只安装在 coverage lane。

## 测试

- 相关测试同进程运行：87/87 passed。
- `bun run check:chat-contract`：server 109/109、desktop 221/221 passed。
- `scripts/pr/pr-quality-workflow.test.ts`：9/9 passed。
- `bun run check:coverage`（Windows / Bun 1.3.12）：Server/API、Agent tools、Agent utils 已生成有效 LCOV；Adapters 和 Desktop 仍受本机 Windows 基线失败影响，因此没有宣称全量通过。
- 上游 CI 使用 Bun 1.3.14；本 PR 先保持 Draft，等待 Ubuntu CI 验证。

## 风险与审核

- 改动涉及 CLI core 测试范围，需要维护者添加 `allow-cli-core-change` 标签并批准。
- 没有降低覆盖率阈值，也没有忽略缺失的 LCOV。
